### PR TITLE
Lock django-debug-toolbar version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ python23_universal_requirements = [
         "pygments",
         "django-libsass>=0.7",
 
-        "django-debug-toolbar>=1.4",
+        "django-debug-toolbar>=1.4,<1.10",
         "django-extensions>=1.0.0",
         "werkzeug",
 


### PR DESCRIPTION
>=1.10 requires Django 1.11