### PR TITLE
(SIO-2507) JavaScript error when visiting web-page

### DIFF
--- a/oioioi/base/static/common/clipboard-setup.js
+++ b/oioioi/base/static/common/clipboard-setup.js
@@ -1,6 +1,8 @@
-new Clipboard('.btn-copy')
-    .on('success', function(e) {
-        e.trigger.outerHTML = '<small><span class="glyphicon glyphicon-ok"></span>' + gettext("copied!") + '</small>';
-    }).on('error', function(e) {
-        e.trigger.outerHTML = '<small>' + gettext("Press Ctrl+C to copy") + '</small>';
-    });
+$(window).on("load", function() {
+    new Clipboard('.btn-copy')
+        .on('success', function (e) {
+            e.trigger.outerHTML = '<small><span class="glyphicon glyphicon-ok"></span>' + gettext("copied!") + '</small>';
+        }).on('error', function (e) {
+            e.trigger.outerHTML = '<small>' + gettext("Press Ctrl+C to copy") + '</small>';
+        });
+});


### PR DESCRIPTION
Not all elements are loaded when Clipboard is being set up. Doing it via window.onload solves the problem.

Solution:
* Wrapped clipboard setup with window.onload

This problem disallowed Cypress to test the code correctly.