### PR TITLE
(no-ticket) Enable custom editor for problemset 

### DIFF
--- a/oioioi/programs/controllers.py
+++ b/oioioi/programs/controllers.py
@@ -612,9 +612,9 @@ class ProgrammingProblemController(ProblemController):
             {'data-languagehintsurl': reverse('get_language_hints')}
         )
 
-        use_editor = False
+        use_editor = settings.USE_ACE_EDITOR
         if problem_instance.contest is not None:
-            use_editor = settings.USE_ACE_EDITOR and problem_instance.contest.enable_editor
+            use_editor = use_editor and problem_instance.contest.enable_editor
 
         code_widget = None
         if use_editor:


### PR DESCRIPTION
As .contest variable is None when the controller handles problemset we can just use the platform default value set by an administrator in settings.py.