### PR TITLE
(no-ticket) Toolbox feature - inquirer only for GUI 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /venv*/
 /.idea/
 /.vscode/
+/.fleet/

--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -2,7 +2,7 @@
 
 # pip requirements:
 #   python ^3.6
-#   inquirer
+#   inquirer     (only for CLI)
 # 
 # system:
 #   docker
@@ -17,7 +17,6 @@
 
 import sys
 import os
-import inquirer
 
 
 BASE_DOCKER_COMMAND = "OIOIOI_UID=$(id -u) docker-compose" + \
@@ -110,6 +109,7 @@ def get_action_from_args() -> Option:
 
 
 def get_action_from_cli() -> Option:
+    import inquirer
     questions = [
         inquirer.List(
             "action",

--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -2,7 +2,7 @@
 
 # pip requirements:
 #   python ^3.6
-#   inquirer     (only for CLI)
+#   inquirer     (only for GUI)
 # 
 # system:
 #   docker
@@ -108,7 +108,7 @@ def get_action_from_args() -> Option:
     return candidates[0]
 
 
-def get_action_from_cli() -> Option:
+def get_action_from_gui() -> Option:
     import inquirer
     questions = [
         inquirer.List(
@@ -142,7 +142,7 @@ def warn_user(action: Option) -> bool:
 
 
 def run() -> None:
-    action = get_action_from_args() or get_action_from_cli()
+    action = get_action_from_args() or get_action_from_gui()
     action.fill_tty(disable=NO_INPUT)
     if action.warn and not NO_INPUT:
         if not warn_user(action):


### PR DESCRIPTION
inquirer is not required when using `./easy_toolbox.py <arg>` 
The package is imported only when using ~~CLI~~ GUI