### PR TITLE
Fix issue #112

### DIFF
--- a/oioioi/base/static/scss/_admin.scss
+++ b/oioioi/base/static/scss/_admin.scss
@@ -8,7 +8,7 @@
   }
 
   tr.form-row:not(.empty-form) {
-    display: contents;
+    display: table-row;
   }
 
   .empty-form {


### PR DESCRIPTION
Fixes instances of admin.TabularInline showing multiple rows as one (#112).
This can be seen for example in the form for changing a user who has more than one related participant object.