### PR TITLE
(SIO-2521) Add user login to confirmation email template

### DIFF
--- a/oioioi/confirmations/templates/confirmations/email_body.txt
+++ b/oioioi/confirmations/templates/confirmations/email_body.txt
@@ -3,6 +3,7 @@
 This is a confirmation that we have received your submission
 to the {{ contest }} contest:
 
+OIOIOI login: {{ user_login }}
 Contest id: {{ contest_id }}
 Problem: {{ problem_shortname }}
 Submission id: {{ submission_id }}

--- a/oioioi/confirmations/tests.py
+++ b/oioioi/confirmations/tests.py
@@ -79,6 +79,9 @@ class TestEmailReceipt(TestCase, SubmitFileMixin):
 
         email = mail.outbox[0].message().as_string()
         del mail.outbox[0]
+        self.assertIn("OIOIOI login: test_user", email)
+        self.assertIn(f"Contest id: {contest.id}", email)
+        self.assertIn(f"Problem: {problem_instance.short_name}", email)
         self.assertIn("Submissions to this task: 2", email)
         self.assertIn("1337 bytes", email)
         proof = re.search(

--- a/oioioi/confirmations/utils.py
+++ b/oioioi/confirmations/utils.py
@@ -110,6 +110,7 @@ def send_submission_receipt_confirmation(request, submission):
         'problem_shortname': proof_data['problem_name'],
         'size': proof_data['size'],
         'full_name': submission.user.get_full_name(),
+        'user_login': submission.user.username
     }
 
     subject = render_to_string('confirmations/email_subject.txt', context)


### PR DESCRIPTION
Resolving https://jira.sio2project.mimuw.edu.pl/browse/SIO-2521

Email template now includes user login. Added simple test for email contents.