### PR TITLE
Add stop command to easy_toolbox

### DIFF
--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -26,8 +26,9 @@ BASE_DOCKER_COMMAND = "OIOIOI_UID=$(id -u) docker-compose" + \
 RAW_COMMANDS = [
     ("build", "Build OIOIOI container from source.", "build", True),
     ("up", "Run all SIO2 containers", "up -d"),
-    ("down", "Stop all SIO2 containers", "down", True),
+    ("down", "Stop and remove all SIO2 containers", "down", True),
     ("run", "Run server", "{exec} web python3 manage.py runserver 0.0.0.0:8000"),
+    ("stop", "Stop all SIO2 containers", "stop"),
     ("bash", "Open command prompt on web container.", "{exec} web bash"),
     ("bash-db", "Open command prompt on database container.", "{exec} db bash"),
     # This one CLEARS the database. Use wisely.


### PR DESCRIPTION

docker-compose stop is useful for restarting non-debug server to reload settings change, for notifications configuration (which requires to reload settings.py inside of worker container)