### PR TITLE
Fix celery's logging and add node names

### DIFF
--- a/oioioi/celery/celery.py
+++ b/oioioi/celery/celery.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import os
 
 from celery import Celery
+from celery.signals import setup_logging
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'oioioi.default_settings')
@@ -14,4 +15,13 @@ app = Celery('oioioi')
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings')
+
+# Make celery use django's logging configuration. Source:
+# https://stackoverflow.com/questions/48289809/celery-logger-configuration
+@setup_logging.connect
+def config_loggers(*args, **kwags):
+    from logging.config import dictConfig
+    from django.conf import settings
+    dictConfig(settings.LOGGING)
+
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/oioioi/default_settings.py
+++ b/oioioi/default_settings.py
@@ -639,6 +639,11 @@ LOGGING = {
             'handlers': ['console', 'emit_notification'],
             'level': 'DEBUG',
             'propagate': True,
+        },
+        'celery': {
+            'handlers': ['console', 'emit_notification'],
+            'level': 'DEBUG',
+            'propagate': True,
         }
     }
 }

--- a/oioioi/deployment/supervisord.conf.template
+++ b/oioioi/deployment/supervisord.conf.template
@@ -37,7 +37,7 @@ stdout_logfile={{ PROJECT_DIR }}/logs/mailnotifyd.log
 stderr_logfile={{ PROJECT_DIR }}/logs/mailnotifyd-err.log
 
 [program:unpackmgr]
-command=celery -A oioioi.celery worker -E -l info -Q unpackmgr -c {{ settings.UNPACKMGR_CONCURRENCY }}
+command=celery -A oioioi.celery worker -n %%h-unpackmgr -E -Q unpackmgr -c {{ settings.UNPACKMGR_CONCURRENCY }}
 startretries=0
 stopwaitsecs=15
 redirect_stderr=false
@@ -45,7 +45,7 @@ stdout_logfile={{ PROJECT_DIR }}/logs/unpackmgr.log
 stderr_logfile={{ PROJECT_DIR }}/logs/unpackmgr-err.log
 
 [program:evalmgr]
-command=celery -A oioioi.celery worker -E -l info -Q evalmgr -c {{ settings.EVALMGR_CONCURRENCY }}
+command=celery -A oioioi.celery worker -n %%h-evalmgr -E -Q evalmgr -c {{ settings.EVALMGR_CONCURRENCY }}
 startretries=0
 stopwaitsecs=15
 redirect_stderr=false
@@ -53,7 +53,7 @@ stdout_logfile={{ PROJECT_DIR }}/logs/evalmgr.log
 stderr_logfile={{ PROJECT_DIR }}/logs/evalmgr-err.log
 
 [program:evalmgr-zeus]
-command=celery -A oioioi.celery worker -E -l info -Q evalmgr-zeus -c 1
+command=celery -A oioioi.celery worker -n %%h-evalmgr-zeus -E -Q evalmgr-zeus -c 1
 startretries=0
 stopwaitsecs=15
 redirect_stderr=false


### PR DESCRIPTION
Resolves: https://github.com/sio2project/oioioi/issues/163
Now the LOGGING dict from default_settings.py is used and the console loglevel is actually info for evalmgr and unpackmgr.

The %%h in the celery node names is replaced by the hostname. The need to set unique node names was mentioned in a warning.