### PR TITLE
(SIO-2515) Fix uploading packages without ins or outs

### DIFF
--- a/oioioi/base/utils/archive.py
+++ b/oioioi/base/utils/archive.py
@@ -124,6 +124,9 @@ class Archive(object):
     def filenames(self):
         return self._archive.filenames()
 
+    def dirnames(self):
+        return self._archive.dirnames()
+
     def extracted_size(self):
         return self._archive.extracted_size()
 
@@ -140,6 +143,12 @@ class BaseArchive(object):
     def filenames(self):
         """
         Return a list of the filenames contained in the archive.
+        """
+        raise NotImplementedError()
+
+    def dirnames(self):
+        """
+        Return a list of the dirnames contained in the archive.
         """
         raise NotImplementedError()
 
@@ -198,6 +207,11 @@ class TarArchive(BaseArchive):
             tarinfo.name for tarinfo in self._archive.getmembers() if tarinfo.isfile()
         ]
 
+    def dirnames(self):
+        return [
+            tarinfo.name for tarinfo in self._archive.getmembers() if tarinfo.isdir()
+        ]
+
     def extracted_size(self):
         total = 0
         for member in self._archive:
@@ -230,6 +244,13 @@ class ZipArchive(BaseArchive):
             zipinfo.filename
             for zipinfo in self._archive.infolist()
             if not zipinfo.is_dir()
+        ]
+
+    def dirnames(self):
+        return [
+            zipinfo.filename
+            for zipinfo in self._archive.infolist()
+            if zipinfo.is_dir()
         ]
 
 

--- a/oioioi/sinolpack/package.py
+++ b/oioioi/sinolpack/package.py
@@ -155,14 +155,14 @@ class SinolPackage(object):
         Otherwise None is returned.
         """
 
-        files = list(map(os.path.normcase, self.archive.filenames()))
-        files = list(map(os.path.normpath, files))
-        toplevel_dirs = set(f.split(os.sep)[0] for f in files)
+        dirs = list(map(os.path.normcase, self.archive.dirnames()))
+        dirs = list(map(os.path.normpath, dirs))
+        toplevel_dirs = set(f.split(os.sep)[0] for f in dirs)
         toplevel_dirs = list(filter(slug_re.match, toplevel_dirs))
         problem_dirs = []
         for dir in toplevel_dirs:
             for required_subdir in ('in', 'out'):
-                if all(f.split(os.sep)[:2] != [dir, required_subdir] for f in files):
+                if all(f.split(os.sep)[:2] != [dir, required_subdir] for f in dirs):
                     break
             else:
                 problem_dirs.append(dir)

--- a/oioioi/sinolpack/tests.py
+++ b/oioioi/sinolpack/tests.py
@@ -721,7 +721,8 @@ class TestSinolPackageInContest(TransactionTestCase, TestStreamingMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Problem.objects.count(), 0)
         self.assertEqual(ProblemInstance.objects.count(), 0)
-        self.assertEqual(ProblemPackage.objects.count(), 0)
+        # Bad packages need to be left over for the error messages
+        self.assertEqual(ProblemPackage.objects.count(), 1)
 
 
 class TestSinolPackageCreator(TestCase, TestStreamingMixin):


### PR DESCRIPTION
Some packages were being rejected, because they didn't have files in `in/` or `out/` and the package validator was getting the directory list from the file list.
The modified test now detects this bug.