### PR TITLE
Allow admins to see unpublished test packages

### DIFF
--- a/oioioi/problems/templates/problems/files.html
+++ b/oioioi/problems/templates/problems/files.html
@@ -20,7 +20,7 @@
                 </thead>
                 <tbody>
                     {% for file in files %}
-                        <tr>
+                        <tr {% if not file.pub_date or file.pub_date > request.timestamp %} class="text-muted" {% endif %}>
                             {% if add_category_field %}
                                 <td>{{ file.category }}</td>
                             {% endif %}

--- a/oioioi/testspackages/tests.py
+++ b/oioioi/testspackages/tests.py
@@ -137,3 +137,18 @@ class TestTestsPackages(TestCase):
         with fake_time(datetime(2012, 8, 5, 0, 12, tzinfo=timezone.utc)):
             response = self.client.get(url)
             self.assertEqual(200, response.status_code)
+
+        self.assertTrue(self.client.login(username='test_admin'))
+        url = reverse('contest_files', kwargs={'contest_id': contest.id})
+        # Admins should see even unpublished test packages
+        with fake_time(datetime(2012, 8, 5, 0, 10, tzinfo=timezone.utc)):
+            response = self.client.get(url)
+            self.assertContains(response, 'some_name.zip')
+            self.assertContains(response, 'some_name2.zip')
+            self.assertEqual(200, response.status_code)
+
+        with fake_time(datetime(2012, 8, 5, 1, 12, tzinfo=timezone.utc)):
+            response = self.client.get(url)
+            self.assertContains(response, 'some_name.zip')
+            self.assertContains(response, 'some_name2.zip')
+            self.assertEqual(200, response.status_code)

--- a/oioioi/testspackages/views.py
+++ b/oioioi/testspackages/views.py
@@ -15,6 +15,7 @@ from oioioi.contests.utils import (
     can_enter_contest,
     contest_exists,
     is_contest_admin,
+    is_contest_basicadmin,
     visible_problem_instances,
 )
 from oioioi.contests.models import ProblemInstance
@@ -30,7 +31,10 @@ def visible_tests_packages(request):
     return [
         tp
         for tp in tests_packages
-        if tp.is_visible(request.timestamp) and tp.package is not None
+        if tp.package is not None and (
+            is_contest_basicadmin(request) or
+            tp.is_visible(request.timestamp)
+        )
     ]
 
 


### PR DESCRIPTION
Closes #165.

For admins, the Downloads page will look like this:
![image](https://github.com/sio2project/oioioi/assets/82606748/0b353505-225f-40f0-bc3b-7b78ec4babe3)