### PR TITLE
Fixup the settings refactor

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -30,7 +30,7 @@ In order to use `easy_toolbox.py` alternative method, check python package requi
 
 To build OIOIOI image run 
 ```bash
-OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml build
+OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml build
 ```
 or
 ```bash
@@ -39,7 +39,7 @@ or
 
 Set your containers up and running
 ```bash
-OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml up -d
+OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml up -d
 ```
 or
 ```bash
@@ -50,7 +50,7 @@ Wait some time for the migration to finish (no more than a few minutes).
 
 Run your web service
 ```bash
-OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml exec web python3 manage.py runserver 0.0.0.0:8000
+OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml exec web python3 manage.py runserver 0.0.0.0:8000
 ```
 or
 ```bash
@@ -63,7 +63,7 @@ Now visit `localhost:8000` and start exploring OIOIOI.
 In order to run unit tests Docker installation is required.
 To do it just run
 ```bash
-docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml exec "web" ../oioioi/test.sh
+docker-compose -f docker-compose-dev.yml exec "web" ../oioioi/test.sh
 ```
 or
 ```bash
@@ -138,7 +138,7 @@ especially that it is more stable approach.
 Whenever you don't have the containers up.
 After running it you should see the following output:
 ```bash
-Running command OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml up -d
+Running command OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml up -d
 ===================================================================================================================================
 Creating network "oioioi_default" with the default driver
 Creating oioioi_broker_1 ... done

--- a/README.rst
+++ b/README.rst
@@ -76,12 +76,12 @@ experimental features enabled.
 
 Prepare the image with::
 
-    OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml build
+    OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml build
 
 Then you can start oioioi with::
 
-    OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml up -d
-    OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml exec web python3 manage.py runserver 0.0.0.0:8000
+    OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml up -d
+    OIOIOI_UID=$(id -u) docker-compose -f docker-compose-dev.yml exec web python3 manage.py runserver 0.0.0.0:8000
 
 to start the infrastructure in the development mode. Current dirrectory with the source code will be bound to /sio2/oioioi/ inside the running container.
 
@@ -89,7 +89,7 @@ oioioi web interface will be available at localhost:8000, and the user admin wit
 
 Additionally you can bind config files and logs folder to the host::
 
-    id=$(docker create oioioi-dev)  #Create oioioi container
+    id=$(docker create sio2project/oioioi-dev)  #Create oioioi container
     docker cp $id:/sio2/deployment deployment  #Copy initial deployment folder from oioioi contanier
     docker rm -v $id  #Remove unneeded container
 
@@ -101,8 +101,8 @@ Running tests on Docker
 For testing purposes we use test.sh script located in oioioi directory. Note it's not the same directory
 you are connected to after using docker exec -it “web” /bin/bash. The default container id that you should use for running tests is "web"::
 
-    docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml exec "web" ../oioioi/test.sh
-    docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml exec "web" ../oioioi/test.sh oioioi/{name_of_the_app}/
+    docker-compose -f docker-compose-dev.yml exec "web" ../oioioi/test.sh
+    docker-compose -f docker-compose-dev.yml exec "web" ../oioioi/test.sh oioioi/{name_of_the_app}/
 
 Running static code analysis tools locally (requires Docker)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/oioioi/default_settings.py
+++ b/oioioi/default_settings.py
@@ -74,11 +74,9 @@ STATEMENT_LANGUAGES = (
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
-# On Unix systems, a value of None will cause Django to use the same
-# timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = os.getenv('OIOIOI_TIMEZONE', None)
+TIME_ZONE = os.getenv('OIOIOI_TIMEZONE', 'UTC')
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html

--- a/oioioi/default_settings.py
+++ b/oioioi/default_settings.py
@@ -36,8 +36,8 @@ PUBLIC_ROOT_URL = 'http://localhost'
 # 'django' - django's http server
 # 'uwsgi' - uwsgi daemon
 # 'uwsgi-http' - uwsgi deamon with built-in http server
-# None - nothing will be run
-SERVER = os.getenv('OIOIOI_SERVER_MODE', None)
+# 'none' - nothing will be ran
+SERVER = os.getenv('OIOIOI_SERVER_MODE', 'none')
 
 DATABASES = {
     'default': {

--- a/oioioi/default_settings.py
+++ b/oioioi/default_settings.py
@@ -146,7 +146,7 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 # Set to true to send user activation emails. Needs an SMTP server to be
 # configured above.
-SEND_USER_ACTIVATION_EMAIL = True
+SEND_USER_ACTIVATION_EMAIL = False
 
 # List of callables that know how to import templates from various sources.
 UNCACHED_TEMPLATE_LOADERS = (

--- a/oioioi/deployment/create_config.py
+++ b/oioioi/deployment/create_config.py
@@ -19,29 +19,6 @@ def error(message):
     sys.exit(1)
 
 
-def get_timezone():
-    ret = ''
-    try:
-        if os.path.isfile('/etc/timezone'):
-            ret = open('/etc/timezone').read().strip()
-        elif os.path.isfile('/etc/sysconfig/clock'):
-            file = open('/etc/sysconfig/clock')
-            for line in file:
-                if 'ZONE' in line:
-                    ret = ''.join(line.split())[6:-1]
-        elif os.path.isfile('/etc/sysconfig/timezone'):
-            file = open('/etc/sysconfig/timezone')
-            for line in file:
-                if 'TIMEZONE' in line:
-                    ret = ''.join(line.split())[10:-1]
-    except IOError:
-        ret = 'GMT'
-    if ret != '':
-        return ret
-    else:
-        return 'GMT'
-
-
 def generate_from_template(dir, filename, context, mode=None):
     dest = os.path.join(dir, filename)
     template = open(os.path.join(basedir, filename + '.template')).read()
@@ -60,7 +37,6 @@ def generate_all(dir, verbose):
             '__CONFIG_VERSION__': str(INSTALLATION_CONFIG_VERSION),
             '__DIR__': dir,
             '__SECRET__': str(uuid.uuid4()),
-            '__TIMEZONE__': get_timezone(),
         },
     )
 

--- a/oioioi/deployment/settings.py.template
+++ b/oioioi/deployment/settings.py.template
@@ -113,7 +113,7 @@ SECRET_KEY = '__SECRET__'
 
 # Set to true to send user activation emails. Needs an SMTP server to be
 # configured above.
-# SEND_USER_ACTIVATION_EMAIL = True
+# SEND_USER_ACTIVATION_EMAIL = False
 
 # Set to True to show the link to the problemset with contests on navbar.
 # PROBLEMSET_LINK_VISIBLE = True

--- a/oioioi/deployment/settings.py.template
+++ b/oioioi/deployment/settings.py.template
@@ -39,8 +39,8 @@ ALLOWED_HOSTS = ['oioioi', '127.0.0.1', 'localhost', 'web']
 # 'django' - django's http server
 # 'uwsgi' - uwsgi daemon
 # 'uwsgi-http' - uwsgi deamon with built-in http server
-# None - nothing will be run
-# SERVER = None
+# 'none' - nothing will be ran
+# SERVER = 'none'
 
 # DATABASES = {
 #     'default': {

--- a/oioioi/deployment/settings.py.template
+++ b/oioioi/deployment/settings.py.template
@@ -57,11 +57,9 @@ ALLOWED_HOSTS = ['oioioi', '127.0.0.1', 'localhost', 'web']
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
-# On Unix systems, a value of None will cause Django to use the same
-# timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = '__TIMEZONE__'
+# TIME_ZONE = 'UTC'
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html

--- a/run_static.sh
+++ b/run_static.sh
@@ -9,7 +9,7 @@ export OIOIOI_UID=$(id -u)
 docker_run_built="docker run --rm --entrypoint=/entrypoint_checks.sh -t sio2project/oioioi-dev "
 
 # can be used without rebuilding the image
-docker_compose_alias="docker-compose -f docker-compose-dev.yml -f extra/docker/docker-compose-dev-noserver.yml "
+docker_compose_alias="docker-compose -f docker-compose-dev.yml "
 docker_compose_exec="${docker_compose_alias} exec web /sio2/oioioi/entrypoint_checks.sh "
 
 # choose the way of running static on docker


### PR DESCRIPTION
- since default_settings.py don't provide a working email configuration, sending account activation emails should be disabled by default. Without this, one can't register new accounts on a dev docker setup.
~~- OIOIOI_SERVER_MODE needs to be set to 'uwsgi-http' at least for dev deployments, otherwise no server is started.~~
- the default value for the SERVER setting should be a string instead of None, since there is no way to unset an env var in docker. With this change one can freely override a value from a Dockerfile in docker-compose.
- None is not a valid TIME_ZONE setting (at least in docker)
- if OIOIOI_TIMEZONE is to be of any use, we shouldn't override TIME_ZONE in settings.py.template by default