### PR TITLE
Fix class name shadow braking user change form in admin panel

### DIFF
--- a/oioioi/base/forms.py
+++ b/oioioi/base/forms.py
@@ -232,7 +232,7 @@ class UserForm(forms.ModelForm):
         PreferencesSaved.send(self, user=instance)
         return instance
 
-class UserChangeForm(UserForm):
+class OioioiUserForm(UserForm):
     confirm_password = forms.CharField(widget=forms.PasswordInput(), required=False)
 
     class Media(object):
@@ -240,7 +240,7 @@ class UserChangeForm(UserForm):
 
     def __init__(self,  *args, **kwargs):
 
-        super(UserChangeForm, self).__init__(*args, **kwargs)
+        super(OioioiUserForm, self).__init__(*args, **kwargs)
         self.user = kwargs.pop('instance', None)
 
     def clean_confirm_password(self):

--- a/oioioi/base/views.py
+++ b/oioioi/base/views.py
@@ -103,7 +103,7 @@ def edit_profile_view(request):
     ensure_preferences_exist_for_user(request.user)
     if request.method == 'POST':
         form = PreferencesFactory().create_form(
-            oioioi.base.forms.UserChangeForm,
+            oioioi.base.forms.OioioiUserForm,
             request.user,
             request.POST,
             allow_login_change=not has_valid_username(request.user),
@@ -116,7 +116,7 @@ def edit_profile_view(request):
             return redirect('index')
     else:
         form = PreferencesFactory().create_form(
-            oioioi.base.forms.UserChangeForm,
+            oioioi.base.forms.OioioiUserForm,
             request.user,
             allow_login_change=not has_valid_username(request.user),
         )


### PR DESCRIPTION
Closes #244.

This small change fixes the issue by renaming the class responsible for enforcing password confirmation when user wants to change its email address.

The `UserChangeForm` class introduced in https://github.com/sio2project/oioioi/commit/363ce7601719240a532cbe0585b6d57eaa70d393 https://github.com/sio2project/oioioi/blob/40a377d3f2d5cd9c94d01f03e197501ce4aab597/oioioi/base/forms.py#L235-L257
shadows the django one imported earlier https://github.com/sio2project/oioioi/blob/40a377d3f2d5cd9c94d01f03e197501ce4aab597/oioioi/base/forms.py#L8-L12 
which is used as a base for admin's user change form https://github.com/sio2project/oioioi/blob/40a377d3f2d5cd9c94d01f03e197501ce4aab597/oioioi/base/forms.py#L266-L270
