### PR TITLE
Change 'registration' to 'sign-up' in the context of registration in SIO

### DIFF
--- a/oioioi/base/registration_backend.py
+++ b/oioioi/base/registration_backend.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.views import PasswordResetView, PasswordResetDoneView
 from django.contrib.sites.requests import RequestSite
 from django.urls import re_path, reverse_lazy
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, RedirectView
 from registration import signals
 from registration.backends.default.views import (
     RegistrationView as DefaultRegistrationView,
@@ -63,19 +63,24 @@ class RegistrationView(DefaultRegistrationView):
 
 
 urlpatterns = [
-    re_path(r'^register/$', RegistrationView.as_view(), name='registration_register'),
+    re_path(r'^sign-up/$', RegistrationView.as_view(), name='sign-up'),
+    re_path(
+        r'^register/$',
+        RedirectView.as_view(pattern_name='/sign-up/', permanent=True),
+        name='registration_redirect',
+    ),
 ]
 
 if not settings.SEND_USER_ACTIVATION_EMAIL:
     urlpatterns += [
         re_path(
-            r'^register/complete/$',
+            r'^sign-up/complete/$',
             TemplateView.as_view(
                 template_name='registration/'
                 'registration_and_activation_complete.html'
             ),
-            name='registration_complete',
-        )
+            name='sign-up_complete',
+        ),
     ]
 
 urlpatterns += [

--- a/oioioi/base/templates/ingredients/navbar-user.html
+++ b/oioioi/base/templates/ingredients/navbar-user.html
@@ -32,7 +32,7 @@ function setFocusToLoginInput(){
                 </div>
                 <div class="form-row">
                     <div class="col"><button type="submit" class="btn btn-primary btn-block">{% trans "Log in" %}</button></div>
-                    <div class="col"><a role="button" class="btn btn-outline-secondary btn-block" href="{% url 'registration_register' %}">{% trans "Register" %}</a></div>
+                    <div class="col"><a role="button" class="btn btn-outline-secondary btn-block" href="{% url 'registration_register' %}">{% trans "Sign up" %}</a></div>
                 </div>
             </form>
         </div>

--- a/oioioi/base/templates/registration/activation_complete.html
+++ b/oioioi/base/templates/registration/activation_complete.html
@@ -1,7 +1,7 @@
 {% extends "simple-centered.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Registration complete" %}{% endblock %}
+{% block title %}{% trans "Sign-up complete" %}{% endblock %}
 
 {% block content %}
     <div class="alert alert-success text-center">

--- a/oioioi/base/templates/registration/activation_email.txt
+++ b/oioioi/base/templates/registration/activation_email.txt
@@ -1,6 +1,6 @@
 {% load i18n %}{% blocktrans %}Welcome to OIOIOI,
 
-to finish the registration, please click on the link below:{% endblocktrans %}
+to finish the sign-up process, please click on the link below:{% endblocktrans %}
 http://{{site}}{% url 'registration_activate' activation_key %}
 
 {% blocktrans %}Best wishes,

--- a/oioioi/base/templates/registration/activation_email_subject.txt
+++ b/oioioi/base/templates/registration/activation_email_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% trans "OIOIOI Registration" %}
+{% load i18n %}{% trans "OIOIOI Sign-up" %}

--- a/oioioi/base/templates/registration/registration_and_activation_complete.html
+++ b/oioioi/base/templates/registration/registration_and_activation_complete.html
@@ -1,12 +1,12 @@
 {% extends "simple-centered.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Registration successful" %}{% endblock %}
+{% block title %}{% trans "Sign-up successful" %}{% endblock %}
 
 {% block content %}
     <div class="alert alert-success text-center">
-        <h1>{% trans "Registration successful" %}</h1>
-        <p>{% trans "Thank you for registering." %}</p>
+        <h1>{% trans "Sign-up successful" %}</h1>
+        <p>{% trans "Thank you for signing up." %}</p>
         <p>{% trans "Your account is now active. You may go ahead and log in now." %}</p>
         <p><a role="button" class="btn btn-primary" href="{% url "auth_login" %}">{% trans "Log in" %}</a></p>
     </div>

--- a/oioioi/base/templates/registration/registration_complete.html
+++ b/oioioi/base/templates/registration/registration_complete.html
@@ -1,12 +1,12 @@
 {% extends "simple-centered.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Registration successful" %}{% endblock %}
+{% block title %}{% trans "Sign-up successful" %}{% endblock %}
 
 {% block content %}
     <div class="alert alert-success">
-        <h1>{% trans "Registration successful" %}</h1>
-        <p>{% trans "Thank you for registering." %}</p>
+        <h1>{% trans "Sign-up successful" %}</h1>
+        <p>{% trans "Thank you for siging up." %}</p>
         <p>{% blocktrans trimmed %}We've e-mailed you instructions for activating the account to
         the e-mail address you submitted. You should be receiving it shortly.
         {% endblocktrans %}</p>

--- a/oioioi/base/templates/registration/registration_form.html
+++ b/oioioi/base/templates/registration/registration_form.html
@@ -3,7 +3,7 @@
 
 {% block title %}
     {% if not user.is_authenticated %}
-    {% trans "Registration" %}
+    {% trans "Sing-up" %}
     {% else %}
     {% trans "Edit your profile" %}
     {% endif %}
@@ -16,13 +16,13 @@
 
 {% block content %}
     {% if not user.is_authenticated %}
-        <h1>{% trans "Registration" %}</h1>
+        <h1>{% trans "Sign-up" %}</h1>
     {% else %}
         <h1>{% trans "Edit your profile" %}</h1>
     {% endif %}
 
     {% if not form.instance %}
-        <p>{% trans "Please fill the form below to register." %}</p>
+        <p>{% trans "Please fill the form below to sign up." %}</p>
     {% endif %}
 
     <form method="post">

--- a/oioioi/base/templates/two_factor/core/login.html
+++ b/oioioi/base/templates/two_factor/core/login.html
@@ -61,7 +61,7 @@
         {% if wizard.steps.current == 'auth' %}
           <div class="form-group">
             <p><a href="{% url 'auth_password_reset' %}">{% trans "Forgot password?" %}</a></p>
-            <p><a href="{% url 'registration_register' %}">{% trans "Want to create an account?" %}</a></p>
+            <p><a href="{% url 'sign-up' %}">{% trans "Want to create an account?" %}</a></p>
           </div>
         {% endif %}
       </div>

--- a/oioioi/base/tests/tests.py
+++ b/oioioi/base/tests/tests.py
@@ -718,7 +718,7 @@ class TestRegistration(TestCase):
     def test_registration_form_fields(self):
         captcha_count = CaptchaStore.objects.count()
         self.assertEqual(captcha_count, 0)
-        response = self.client.get(reverse('registration_register'))
+        response = self.client.get(reverse('sign-up'))
         captcha_count = CaptchaStore.objects.count()
         self.assertEqual(captcha_count, 1)
         form = response.context['form']
@@ -726,14 +726,14 @@ class TestRegistration(TestCase):
         self.assertIn('last_name', form.fields)
 
     def _register_user(self, terms_accepted=True, pass_captcha=True):
-        response = self.client.get(reverse('registration_register'))
+        response = self.client.get(reverse('sign-up'))
         captcha_count = CaptchaStore.objects.count()
         self.assertEqual(captcha_count, 1)
         captcha = CaptchaStore.objects.all()[0]
         if not pass_captcha:
             captcha.response += "z"
         self.client.post(
-            reverse('registration_register'),
+            reverse('sign-up'),
             {
                 'username': 'test_foo',
                 'first_name': 'Foo',
@@ -1329,7 +1329,7 @@ class TestPreferences(TestCase):
         self.assertContains(response, 'Edycja profilu')
 
     def test_registration_preferences(self):
-        response = self.client.get(reverse('registration_register'))
+        response = self.client.get(reverse('sign-up'))
         self.assertContains(response, 'Preferred language')
 
         self.assertTrue(self.client.login(username='test_user'))
@@ -1347,7 +1347,7 @@ class TestPreferences(TestCase):
         self.assertEqual(response.status_code, 200)
         self.client.logout()
 
-        response = self.client.get(reverse('registration_register'))
+        response = self.client.get(reverse('sign-up'))
         self.assertContains(response, 'Preferred language')
 
 

--- a/oioioi/contests/templates/contests/index-no-contests.html
+++ b/oioioi/contests/templates/contests/index-no-contests.html
@@ -5,7 +5,7 @@
 {% block content %}
 {% url 'oioioiadmin:contests_contest_add' as new_contest_link %}
 {% url 'auth_login' as login_link %}
-{% url 'registration_register' as reg_link %}
+{% url 'sign-up' as reg_link %}
 <div class="empty-space-filler text-center">
     {% if user.is_superuser %}
         {% blocktrans %}
@@ -15,7 +15,7 @@
     {% elif user.is_anonymous %}
         {% blocktrans %}
             <p>There are no contests available to logged out users.</p>
-            <p>Please <a href="{{ login_link }}">log in</a> or <a href="{{ reg_link }}">register</a>.</p>
+            <p>Please <a href="{{ login_link }}">log in</a> or <a href="{{ reg_link }}">sign up</a>.</p>
         {% endblocktrans %}
     {% else %}
         {% blocktrans %}


### PR DESCRIPTION
SIO users often did not distinguish between contest registration and system registration. For this reason, registration for the SIO was changed to sign-up.