### PR TITLE
Add the contest owner permission

### DIFF
--- a/oioioi/base/templatetags/check_perm.py
+++ b/oioioi/base/templatetags/check_perm.py
@@ -19,12 +19,7 @@ class CheckPermNode(Node):
             context[self.var] = False
         else:
             user = context['user']
-            if perm == 'contests.contest_basicadmin':
-                context[self.var] = user.has_perm(perm, obj) or user.has_perm(
-                    'contests.contest_admin', obj
-                )
-            else:
-                context[self.var] = user.has_perm(perm, obj)
+            context[self.var] = user.has_perm(perm, obj)
         return ''
 
 

--- a/oioioi/base/utils/user_selection.py
+++ b/oioioi/base/utils/user_selection.py
@@ -154,6 +154,11 @@ class UserSelectionField(forms.CharField):
     def prepare_value(self, value):
         if isinstance(value, User):
             return value.username
+        if isinstance(value, int):
+            try:
+                return User.objects.get(id=value).username
+            except User.DoesNotExist:
+                pass
         return super(UserSelectionField, self).prepare_value(value)
 
     def to_python(self, value):

--- a/oioioi/contests/auth.py
+++ b/oioioi/contests/auth.py
@@ -26,6 +26,8 @@ class ContestPermissionsAuthBackend(object):
             if user.is_superuser:
                 return Q_always_true()
             query = Q(contestpermission__permission=perm, contestpermission__user=user)
+            if perm == 'contests.contest_admin':
+                query |= self.filter_for_perm(obj_class, 'contests.contest_owner', user)
             if perm == 'contests.contest_basicadmin':
                 query |= self.filter_for_perm(obj_class, 'contests.contest_admin', user)
             return query
@@ -36,6 +38,10 @@ class ContestPermissionsAuthBackend(object):
             return False
         if obj is None or not isinstance(obj, Contest):
             return False
+        if perm == 'contests.contest_admin' and self.has_perm(
+            user_obj, 'contests.contest_owner', obj
+        ):
+            return True
         if perm == 'contests.contest_basicadmin' and self.has_perm(
             user_obj, 'contests.contest_admin', obj
         ):

--- a/oioioi/contests/controllers.py
+++ b/oioioi/contests/controllers.py
@@ -154,15 +154,12 @@ class RegistrationController(RegisteredSubclassesBase, ObjectWithMixins):
             if not hasattr(backend, 'filter_for_perm'):
                 continue
             filt |= (
-                backend.filter_for_perm(Contest, 'contests.contest_admin', request.user)
+                backend.filter_for_perm(Contest, 'contests.contest_basicadmin', request.user)
                 | backend.filter_for_perm(
                     Contest, 'contests.contest_observer', request.user
                 )
                 | backend.filter_for_perm(
                     Contest, 'contests.personal_data', request.user
-                )
-                | backend.filter_for_perm(
-                    Contest, 'contests.contest_basicadmin', request.user
                 )
             )
         return filt

--- a/oioioi/contests/fixtures/test_permissions.json
+++ b/oioioi/contests/fixtures/test_permissions.json
@@ -71,6 +71,24 @@
             "date_joined": "2012-07-31T20:27:58.768Z"
         }
     },
+    {
+        "pk": 1107,
+        "model": "auth.user",
+        "fields": {
+            "username": "test_contest_owner",
+            "first_name": "Test",
+            "last_name": "Contest owner",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-31T20:27:58.768Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "test_personal_data@example.com",
+            "date_joined": "2012-07-31T20:27:58.768Z"
+        }
+    },
   {
     "pk": 1,
     "model": "contests.contestpermission",
@@ -111,6 +129,17 @@
       "permission": "contests.contest_basicadmin",
       "user": [
         "test_contest_basicadmin"
+      ],
+      "contest": "c"
+    }
+  },
+  {
+    "pk": 5,
+    "model": "contests.contestpermission",
+    "fields": {
+      "permission": "contests.contest_owner",
+      "user": [
+        "test_contest_owner"
       ],
       "contest": "c"
     }

--- a/oioioi/contests/models.py
+++ b/oioioi/contests/models.py
@@ -669,6 +669,7 @@ class RoundTimeExtension(models.Model):
 
 
 contest_permissions = EnumRegistry()
+contest_permissions.register('contests.contest_owner', _("Owner"))
 contest_permissions.register('contests.contest_admin', _("Admin"))
 contest_permissions.register('contests.contest_basicadmin', _("Basic Admin"))
 contest_permissions.register('contests.contest_observer', _("Observer"))

--- a/oioioi/contests/tests/tests.py
+++ b/oioioi/contests/tests/tests.py
@@ -1635,6 +1635,7 @@ class TestPermissions(TestCase):
     fixtures = [
         'test_users',
         'test_contest',
+        'test_extra_contests',
         'test_full_package',
         'test_problem_instance',
         'test_submission',
@@ -1650,11 +1651,11 @@ class TestPermissions(TestCase):
         return request
 
     def setUp(self):
-        self.contest = Contest.objects.get()
+        self.contest = Contest.objects.get(id='c')
         self.contest.controller_name = 'oioioi.contests.tests.PrivateContestController'
         self.contest.save()
         self.ccontr = self.contest.controller
-        self.round = Round.objects.get()
+        self.round = Round.objects.get(contest=self.contest)
         self.round.start_date = datetime(2012, 7, 31, tzinfo=timezone.utc)
         self.round.end_date = datetime(2012, 8, 5, tzinfo=timezone.utc)
         self.round.save()
@@ -1739,25 +1740,272 @@ class TestPermissions(TestCase):
             self.assertTrue(self.user.has_perm(perm, self.contest))
             cperm.delete()
 
+    def try_post_perm(self, url, cid, perm, should_fail, user=None):
+        user = user or self.user
+        qs = ContestPermission.objects.filter(
+            user=user,
+            contest_id=cid,
+            permission=perm,
+        )
+        self.assertEqual(qs.count(), 0)
+
+        data = {
+            'user': user.username,
+            'contest': cid,
+            'permission': perm,
+        }
+
+        resp = self.client.post(url, data, follow=True)
+        if resp.status_code == 403:
+            self.assertTrue(should_fail)
+            return
+        self.assertEqual(resp.status_code, 200)
+        if should_fail:
+            self.assertEqual(qs.count(), 0)
+            return
+        self.assertEqual(qs.count(), 1)
+        qs.delete()
+
+    @override_settings(CONTEST_MODE=ContestMode.neutral)
+    def test_contestpermission_admin(self):
+        list_url = reverse(
+            'oioioiadmin:contests_contestpermission_changelist',
+            kwargs={'contest_id': self.contest.id},
+        )
+        list_url_another_contest = reverse(
+            'oioioiadmin:contests_contestpermission_changelist',
+            kwargs={'contest_id': 'c1'},
+        )
+        list_url_nocontest = reverse(
+            'noncontest:oioioiadmin:contests_contestpermission_changelist',
+        )
+        add_url = reverse(
+            'oioioiadmin:contests_contestpermission_add',
+            kwargs={'contest_id': self.contest.id},
+        )
+        add_url_nocontest = reverse(
+            'noncontest:oioioiadmin:contests_contestpermission_add',
+        )
+        # Only superusers and contest owners should see these pages
+        for u in (
+            self.observer, self.cadmin, self.badmin, self.pdata, self.user,
+        ):
+            self.client.force_login(u)
+            for url in (
+                list_url, add_url, list_url_nocontest, add_url_nocontest,
+            ):
+                self.assertEqual(self.client.get(url).status_code, 403)
+
+        perm_different_contest = ContestPermission(
+            user=self.user,
+            contest_id='c1',
+            permission='contests.personal_data',
+        )
+
+        for u in (self.cowner, self.superuser):
+            self.client.force_login(u)
+            for url in (list_url, add_url):
+                self.assertEqual(self.client.get(url).status_code, 200)
+            resp = self.client.get(list_url)
+            # All perms should be visible on the list. We check for the users'
+            # names here.
+            self.assertContains(resp, 'Test Contest owner')
+            self.assertContains(resp, 'Test Contest admin')
+            self.assertContains(resp, 'Test Contest basicadmin')
+            self.assertNotContains(resp, 'Test User')
+
+            perm_different_contest.save()
+            # This shouldn't be visible, since it's in a different contest...
+            self.assertNotContains(resp, 'Test User')
+            # ... but a superuser with no selected contest should see it.
+            if u == self.cowner:
+                # This will have been redirected to the last contest
+                resp = self.client.get(list_url_nocontest)
+                self.assertEqual(resp.status_code, 403)
+                resp = self.client.get(list_url_another_contest)
+                self.assertEqual(resp.status_code, 403)
+            else:
+                resp = self.client.get(list_url_nocontest)
+                self.assertEqual(resp.status_code, 200)
+                self.assertContains(resp, 'Test Contest owner')
+                self.assertContains(resp, 'Test Contest admin')
+                self.assertContains(resp, 'Test Contest basicadmin')
+                self.assertContains(resp, 'Test User')
+            perm_different_contest.delete()
+
+            # Creating new ContestPermission objects for self.user
+            for perm in self.perms_list:
+                # This should fail only for contest owners trying to add
+                # another contest owner
+                self.try_post_perm(
+                    add_url,
+                    self.contest.id,
+                    perm,
+                    u == self.cowner and perm == 'contests.contest_owner',
+                )
+                # Different contest should always fail...
+                self.try_post_perm(
+                    add_url,
+                    'c1',
+                    perm,
+                    True,
+                )
+                # ... except for a superuser with no selected contest.
+                self.try_post_perm(
+                    add_url_nocontest,
+                    'c1',
+                    perm,
+                    u == self.cowner,
+                )
+
+                # Editing objects, mostly same as above
+                tmp_perm = ContestPermission.objects.create(
+                    user=self.user,
+                    contest=self.contest,
+                    permission='nonexistent_permission',
+                )
+
+                cid = self.contest.id
+                # Different contest should always fail...
+                change_url = reverse(
+                    'oioioiadmin:contests_contestpermission_change',
+                    kwargs={'object_id': tmp_perm.id, 'contest_id': cid},
+                )
+                self.try_post_perm(
+                    change_url,
+                    'c1',
+                    perm,
+                    True,
+                )
+
+                # the url is still up to date
+                self.try_post_perm(
+                    change_url,
+                    self.contest.id,
+                    perm,
+                    u == self.cowner and perm == 'contests.contest_owner',
+                )
+
+                # ... except for a superuser with no selected contest.
+                tmp_perm.save()
+                change_url = reverse(
+                    'noncontest:oioioiadmin:contests_contestpermission_change',
+                    kwargs={'object_id': tmp_perm.id,},
+                )
+                self.try_post_perm(
+                    change_url,
+                    'c1',
+                    perm,
+                    u == self.cowner,
+                )
+                tmp_perm.delete()
+
+        # Deleting
+        perm_different_contest.save()
+        # 'post' is to bypass confirmation screen
+        data_owner = {
+            'post': 'yes',
+            'action': 'delete_selected',
+            '_selected_action': ContestPermission.objects.get(
+                permission='contests.contest_owner').id,
+        }
+        data_admin = {
+            'post': 'yes',
+            'action': 'delete_selected',
+            '_selected_action': ContestPermission.objects.get(
+                permission='contests.contest_admin').id,
+        }
+        data_different_contest = {
+            'post': 'yes',
+            'action': 'delete_selected',
+            '_selected_action': perm_different_contest.id,
+        }
+
+        self.client.force_login(self.cadmin)
+        resp = self.client.post(list_url, data_owner)
+        self.assertEqual(resp.status_code, 403)
+        resp = self.client.post(list_url, data_admin)
+        self.assertEqual(resp.status_code, 403)
+
+        self.client.force_login(self.cowner)
+        resp = self.client.post(list_url, data_owner)
+        self.assertEqual(resp.status_code, 403)
+        resp = self.client.post(list_url, data_different_contest, follow=True)
+        # Verifying this is tricky
+        self.assertEqual(resp.status_code, 200)
+        redir_url = resp.redirect_chain[-1]
+        resp = self.client.post(redir_url, data_different_contest, follow=True)
+        self.assertEqual(resp.status_code, 404)
+        resp = self.client.post(
+            list_url_another_contest,
+            data_different_contest,
+            follow=True,
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(ContestPermission.objects.filter(
+            id=perm_different_contest.id).count(), 1)
+
+        self.assertEqual(ContestPermission.objects.filter(
+            permission='contests.contest_admin').count(), 1)
+        resp = self.client.post(list_url, data_admin)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(ContestPermission.objects.filter(
+            permission='contests.contest_admin').count(), 0)
+
+        self.client.force_login(self.superuser)
+        resp = self.client.post(list_url, data_different_contest, follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(ContestPermission.objects.filter(
+            id=perm_different_contest.id).count(), 1)
+
+        resp = self.client.post(
+            list_url_another_contest,
+            data_different_contest,
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(ContestPermission.objects.filter(
+            id=perm_different_contest.id).count(), 0)
+
+        resp = self.client.post(list_url, data_owner)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(ContestPermission.objects.filter(
+            permission='contests.contest_owner').count(), 0)
+
     def test_menu(self):
         unregister_contest_dashboard_view(simpleui_contest_dashboard)
         unregister_contest_dashboard_view(teachers_contest_dashboard)
-
-        self.assertTrue(self.client.login(username='test_contest_admin'))
-        response = self.client.get(
-            reverse('default_contest_view', kwargs={'contest_id': self.contest.id}),
-            follow=True,
+        url = reverse(
+            'default_contest_view',
+            kwargs={'contest_id': self.contest.id}
         )
+
+        self.client.force_login(self.cadmin)
+        response = self.client.get(url, follow=True)
         self.assertNotContains(response, 'System Administration')
         self.assertContains(response, 'Contest Administration')
+        self.assertNotContains(response, 'Contest rights')
         self.assertNotContains(response, 'Observer Menu')
 
-        self.assertTrue(self.client.login(username='test_observer'))
-        response = self.client.get(
-            reverse('problems_list', kwargs={'contest_id': self.contest.id}),
-            follow=True,
-        )
+        self.client.force_login(self.observer)
+        response = self.client.get(url, follow=True)
+        self.assertNotContains(response, 'Contest Administration')
+        self.assertNotContains(response, 'Contest rights')
         self.assertContains(response, 'Observer Menu')
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(url, follow=True)
+        self.assertContains(response, 'System Administration')
+        # The menus are duplicated in the html and this entry
+        # should only appear once in the visible part.
+        self.assertContains(response, 'Contest rights', count=2)
+        self.assertContains(response, 'Contest Administration')
+
+        self.client.force_login(self.cowner)
+        response = self.client.get(url, follow=True)
+        self.assertNotContains(response, 'System Administration')
+        # Same as above
+        self.assertContains(response, 'Contest rights', count=2)
+        self.assertContains(response, 'Contest Administration')
 
 
 class TestPermissionsBasicAdmin(TestCase):

--- a/oioioi/contests/utils.py
+++ b/oioioi/contests/utils.py
@@ -309,6 +309,17 @@ def administered_contests(request):
 
 @make_request_condition
 @request_cached
+def is_contest_owner(request):
+    """Checks if the user is the owner of the current contest.
+    This permission level allows full access to all contest functionality
+    and additionally permits managing contest permissions for a given contest
+    with the exception of contest ownerships.
+    """
+    return request.user.has_perm('contests.contest_owner', request.contest)
+
+
+@make_request_condition
+@request_cached
 def is_contest_admin(request):
     """Checks if the user is the contest admin of the current contest.
     This permission level allows full access to all contest functionality.

--- a/oioioi/contests/utils.py
+++ b/oioioi/contests/utils.py
@@ -328,12 +328,8 @@ def is_contest_admin(request):
 
 
 def can_admin_contest(user, contest):
-    """Checks if the user should be allowed on the admin pages of the contest.
-    This is the same level of permissions as is_contest_basicadmin.
-    """
-    return user.has_perm('contests.contest_admin', contest) or user.has_perm(
-        'contests.contest_basicadmin', contest
-    )
+    """Checks if the user should be allowed on the admin pages of the contest."""
+    return user.has_perm('contests.contest_basicadmin', contest)
 
 
 @make_request_condition

--- a/oioioi/problems/views.py
+++ b/oioioi/problems/views.py
@@ -113,10 +113,7 @@ def show_problem_attachment_view(request, attachment_id):
 def _get_package(request, package_id, contest_perm=None):
     package = get_object_or_404(ProblemPackage, id=package_id)
     if package.contest:
-        has_perm = request.user.has_perm(contest_perm, package.contest) or (
-            contest_perm == 'contests.contest_basicadmin'
-            and request.user.has_perm('contests.contest_admin', package.contest)
-        )
+        has_perm = request.user.has_perm(contest_perm, package.contest)
     elif package.problem:
         has_perm = can_admin_problem(request, package.problem)
     else:


### PR DESCRIPTION
Close #174.

Also make the user field in certain object editing forms default to the username (which needs to be posted) instead of an id.