### PR TITLE
Fix grouping of tasks in task archive

### DIFF
--- a/oioioi/problems/models.py
+++ b/oioioi/problems/models.py
@@ -813,6 +813,23 @@ class OriginInfoValueLocalization(models.Model):
         return str("{} - {}".format(self.origin_info_value, self.language))
 
 
+class FakeOriginInfoValue(object):
+    value = None
+    order = float('inf')
+    cat = None
+
+    def __init__(self, category):
+        self.cat = category
+
+    def __eq__(self, other):
+        if type(other) is FakeOriginInfoValue:
+            return self.cat == other.cat
+        return False
+
+    def __hash__(self):
+        return hash(self.cat)
+
+
 @_localized('full_name')
 
 class DifficultyTag(models.Model):

--- a/oioioi/problems/utils.py
+++ b/oioioi/problems/utils.py
@@ -23,6 +23,7 @@ from oioioi.problems.models import (
     ProblemStatement,
     ProblemStatistics,
     UserStatistics,
+    FakeOriginInfoValue,
 )
 from oioioi.programs.models import (
     GroupReport,
@@ -359,21 +360,7 @@ def get_prefetched_value(problem, category):
     for oiv in problem.origininfovalue_set.all():
         if oiv.category == category:
             return oiv
-
-    class FakeOriginInfoValue(object):
-        value = None
-        order = float('inf')
-        cat = category
-
-        def __eq__(self, other):
-            if type(other) is FakeOriginInfoValue:
-                return self.cat == other.cat
-            return False
-
-        def __hash__(self):
-            return hash(self.cat)
-
-    return FakeOriginInfoValue()
+    return FakeOriginInfoValue(category)
 
 
 def show_proposal_form(problem, user):


### PR DESCRIPTION
Previously, when `get_prefetched_value()` would return `FakeOriginInfoValue` the tasks wouldn't group properly in task archive because of https://github.com/sio2project/oioioi/blob/8f59544087f0652d4c85d18afc4d07d6aa148971/oioioi/problems/views.py#L741-L743 because `FakeOriginInfoValue` was a local class and it wasn't grouped together by `groupby`:
![image](https://github.com/sio2project/oioioi/assets/22548407/3a3abe0c-b723-4588-8316-cac72e11d839)

Now that `FakeOriginInfoValue` is a global class, `groupby` groups tasks properly:
![image](https://github.com/sio2project/oioioi/assets/22548407/6bd38058-907d-4e43-b2bc-ec01e1a01094)
