### PR TITLE
Added password validation

### DIFF
--- a/oioioi/base/validators.py
+++ b/oioioi/base/validators.py
@@ -1,0 +1,75 @@
+import re
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+from django.contrib.auth import password_validation
+
+class NumberValidator(object):
+    def validate(self, password, user=None):
+        if not re.findall('\d', password):
+            raise ValidationError(
+                _("The password must contain at least 1 digit, 0-9."),
+                code='password_no_number',
+            )
+
+    def get_help_text(self):
+        return _(
+            "Your password must contain at least 1 digit, 0-9."
+        )
+
+
+class UppercaseValidator(object):
+    def validate(self, password, user=None):
+        if not re.findall('[A-Z]', password):
+            raise ValidationError(
+                _("The password must contain at least 1 uppercase letter, A-Z."),
+                code='password_no_upper',
+            )
+
+    def get_help_text(self):
+        return _(
+            "Your password must contain at least 1 uppercase letter, A-Z."
+        )
+
+
+class LowercaseValidator(object):
+    def validate(self, password, user=None):
+        if not re.findall('[a-z]', password):
+            raise ValidationError(
+                _("The password must contain at least 1 lowercase letter, a-z."),
+                code='password_no_lower',
+            )
+
+    def get_help_text(self):
+        return _(
+            "Your password must contain at least 1 lowercase letter, a-z."
+        )
+
+
+class SymbolValidator(object):
+    def validate(self, password, user=None):
+        if not re.findall('[()[\]{}|\\`~!@#$%^&*_\-+=;:\'",<>./?]', password):
+            raise ValidationError(
+                _("The password must contain at least 1 symbol: " +
+                  "()[]{}|\`~!@#$%^&*_-+=;:'\",<>./?"),
+                code='password_no_symbol',
+            )
+
+    def get_help_text(self):
+        return _(
+            "Your password must contain at least 1 symbol: " +
+            "()[]{}|\`~!@#$%^&*_-+=;:'\",<>./?"
+        )
+
+
+def get_validators():
+    validators = []
+    
+    validators.append(NumberValidator())
+    validators.append(UppercaseValidator())
+    validators.append(LowercaseValidator())
+    validators.append(SymbolValidator())
+    validators.append(password_validation.MinimumLengthValidator(8))
+
+    return validators
+


### PR DESCRIPTION
According to FRI privacy policy passwords needs to have:
      >min 8 characters
      >contain a lowercase and uppercase letter, as well as digit and special character

This PR covers that issue. 
For it to work, the following needs to be added to the settings.py:

AUTH_PASSWORD_VALIDATORS = [
    {
        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
        "OPTIONS": {
            "min_length": 8,
        },
    },
    {'NAME': 'oioioi.base.validators.NumberValidator', },
    {'NAME': 'oioioi.base.validators.UppercaseValidator', },
    {'NAME': 'oioioi.base.validators.LowercaseValidator', },
    {'NAME': 'oioioi.base.validators.SymbolValidator', },
]