### PR TITLE
Allow for changing the submission size limit

### DIFF
--- a/oioioi/default_settings.py
+++ b/oioioi/default_settings.py
@@ -715,6 +715,7 @@ PRINTING_COMMAND = ['lp', '-o landscape', '-o sides=two-sided-short-edge']
 # To get unlimited submissions count set to 0.
 DEFAULT_SUBMISSIONS_LIMIT = 10
 WARN_ABOUT_REPEATED_SUBMISSION = True
+DEFAULT_SUBMISSION_SIZE_LIMIT = 1024 * 100  # in bytes
 
 # Only used if 'testrun' app is enabled.
 # To get unlimited test runs set to 0.

--- a/oioioi/programs/controllers.py
+++ b/oioioi/programs/controllers.py
@@ -18,6 +18,7 @@ from oioioi.base.utils.inputs import narrow_input_field
 from oioioi.base.widgets import AceEditorWidget
 from oioioi.contests.controllers import ContestController, submission_template_context
 from oioioi.contests.models import ScoreReport, SubmissionReport
+from oioioi.sinolpack.models import ExtraConfig
 from oioioi.contests.utils import (
     is_contest_admin,
     is_contest_basicadmin,
@@ -419,8 +420,13 @@ class ProgrammingProblemController(ProblemController):
 
         submission.save()
 
-    def get_submission_size_limit(self, problem_instance):
-        return 102400  # in bytes
+    def get_submission_size_limit(self, problem_instance): # in bytes
+        return ExtraConfig.objects.get(
+            problem_id=problem_instance.problem_id,
+        ).parsed_config.get(
+            'submission_size_limit',
+            settings.DEFAULT_SUBMISSION_SIZE_LIMIT,
+        )
 
     def check_repeated_submission(self, request, problem_instance, form):
         return (
@@ -463,12 +469,19 @@ class ProgrammingProblemController(ProblemController):
                 _("This language is not allowed for selected problem.")
             )
 
+        controller = problem_instance.controller
+        size_limit = controller.get_submission_size_limit(problem_instance)
+
         if is_file_chosen:
+            if cleaned_data['file'].size > size_limit:
+                raise ValidationError(_("File size limit exceeded."))
             code = cleaned_data['file'].read()
         else:
+            if len(cleaned_data['code']) > size_limit:
+                raise ValidationError(_("Code length limit exceeded."))
             code = cleaned_data['code'].encode('utf-8')
 
-        if problem_instance.controller.check_repeated_submission(
+        if controller.check_repeated_submission(
             request, problem_instance, form
         ):
             lines = iter(code.splitlines())
@@ -563,17 +576,6 @@ class ProgrammingProblemController(ProblemController):
         form.set_custom_field_attributes(field_name, problem_instance)
 
     def adjust_submission_form(self, request, form, problem_instance):
-        controller = problem_instance.controller
-        size_limit = controller.get_submission_size_limit(problem_instance)
-
-        def validate_file_size(file):
-            if file.size > size_limit:
-                raise ValidationError(_("File size limit exceeded."))
-
-        def validate_code_length(code):
-            if len(code) > size_limit:
-                raise ValidationError(_("Code length limit exceeded."))
-
         def validate_language(file):
             ext = get_extension(file.name)
             if ext not in get_allowed_languages_extensions(problem_instance):
@@ -595,7 +597,7 @@ class ProgrammingProblemController(ProblemController):
             required=False,
             widget=CancellableFileInput,
             allow_empty_file=False,
-            validators=[validate_file_size, validate_language],
+            validators=[validate_language],
             label=_("File"),
             help_text=mark_safe(
                 _(
@@ -641,7 +643,6 @@ class ProgrammingProblemController(ProblemController):
         form.fields['code'] = forms.CharField(
             required=False,
             label=_("Code"),
-            validators=[validate_code_length],
             widget=code_widget
         )
 


### PR DESCRIPTION
I think that either this code or something that was used for XXVII OI's awesome "Pisarze" ("Writers") task should be upstreamed.
There might be more tasks that will need this in the future (I came across one recently) and imho SZKOpuł should support this too, since "Pisarze" are uploaded there.

This implementation allows for the submission size limit to be overriden in a problem package's config.
Validation had to be moved from the form fields to the form itself as the limit changes based on the chosen task.