### PR TITLE
Address a few warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get update && \
         sudo \
         libstdc++6 \
         zlib1g \
+        sox \
+        flite \
         locales \
         python3-pip && \
     apt-get clean

--- a/oioioi/base/urls.py
+++ b/oioioi/base/urls.py
@@ -25,14 +25,16 @@ urlpatterns = [
     # login view which can be used to bypass 2FA.
     #   re_path(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     re_path(r'^admin/logout/$', views.logout_view),
-    re_path(r'^admin/', admin.site.urls),
 ]
 
 urlpatterns += [
     re_path(r'^$', main_page_view, name='index'),
 ]
 
-noncontest_patterns = []
+noncontest_patterns = [
+    # The contest versions are included by contests.admin.contest_site
+    re_path(r'^admin/', admin.site.urls),
+]
 
 if settings.USE_API:
     urlpatterns += [

--- a/oioioi/clock/urls.py
+++ b/oioioi/clock/urls.py
@@ -5,5 +5,6 @@ from oioioi.clock import views
 app_name = 'clock'
 
 urlpatterns = [
-    re_path(r'^admin/time/$', views.admin_time, name='admin_time'),
+    # Don't use the 'admin/' prefix, as that sometimes results in breakage.
+    re_path(r'^admin_time/$', views.admin_time, name='admin_time'),
 ]

--- a/oioioi/problems/utils.py
+++ b/oioioi/problems/utils.py
@@ -296,7 +296,7 @@ def generate_model_solutions_context(request, problem_instance):
                     percentage_statuses[s.id] = '25'
                 elif time_ratio <= 0.50:
                     percentage_statuses[s.id] = '50'
-                    if submissions_percentage_statuses[s.id] is not '100':
+                    if submissions_percentage_statuses[s.id] != '100':
                         submissions_percentage_statuses[s.id] = '50'
                 else:
                     percentage_statuses[s.id] = '100'

--- a/oioioi/questions/views.py
+++ b/oioioi/questions/views.py
@@ -1,5 +1,5 @@
 import calendar
-import datetime
+from datetime import datetime, timezone
 
 from django.conf import settings
 from django.contrib import messages as django_messages
@@ -444,8 +444,9 @@ def increment_template_usage_view(request, template_id=None):
 @jsonify
 @enforce_condition(contest_exists)
 def check_new_messages_view(request, topic_id):
-    timestamp = request.GET['timestamp']
-    unix_date = datetime.datetime.fromtimestamp(int(timestamp))
+    timestamp = int(request.GET['timestamp'])
+    # utcfromtimestamp returns a naive datetime
+    date = datetime.utcfromtimestamp(timestamp).replace(tzinfo=timezone.utc)
     output = [
         [
             x.topic,
@@ -454,7 +455,7 @@ def check_new_messages_view(request, topic_id):
         ]
         for x in visible_messages(request)
         .filter(top_reference_id=topic_id)
-        .filter(date__gte=unix_date)
+        .filter(date__gte=date)
     ]
     return {'timestamp': request_time_seconds(request), 'messages': output}
 


### PR DESCRIPTION
- `(urls.W005) URL namespace 'contest:oioioiadmin' isn't unique. You may not be able to reverse all URLs in this namespace` - from manage.py
- `RuntimeWarning: DateTimeField Message.date received a naive datetime while time zone support is active.` - from uwsgi/runserver logs
- `SyntaxWarning: "is not" with a literal. Did you mean "!="?` - from at least docker build logs
- captcha check complaining about missing sox and flite - from at least pytest

I don't know of any more visible warnings other than those in logs of celery and filetracker, which should be addressed by updating dependencies outside this PR.
If I missed some, please tell me.