### PR TITLE
Fix contest progress bar

### DIFF
--- a/oioioi/clock/static/common/clocks.js
+++ b/oioioi/clock/static/common/clocks.js
@@ -132,17 +132,14 @@ $(function() {
         countdownProgressText.text(Math.floor(completion * 100) + "%");
 
         if (completion < 0.5) {
-            countdownProgressFill.removeClass('progress-bar-warning');
-            countdownProgressFill.removeClass('progress-bar-danger');
-            countdownProgressFill.addClass('progress-bar-success');
+            countdownProgressFill.removeClass('bg-warning');
+            countdownProgressFill.removeClass('bg-danger');
         } else if (completion < 0.8) {
-            countdownProgressFill.removeClass('progress-bar-success');
-            countdownProgressFill.removeClass('progress-bar-danger');
-            countdownProgressFill.addClass('progress-bar-warning');
+            countdownProgressFill.removeClass('bg-danger');
+            countdownProgressFill.addClass('bg-warning');
         } else {
-            countdownProgressFill.removeClass('progress-bar-success');
-            countdownProgressFill.removeClass('progress-bar-warning');
-            countdownProgressFill.addClass('progress-bar-danger');
+            countdownProgressFill.removeClass('bg-warning');
+            countdownProgressFill.addClass('bg-danger');
         }
     }
 

--- a/oioioi/clock/static/common/clocks.js
+++ b/oioioi/clock/static/common/clocks.js
@@ -124,25 +124,25 @@ $(function() {
 
         // Show countdown progress
         countdownProgressFill.css('visibility', 'visible');
-        const completion = remainingSeconds / roundDuration;
+        const completion = 1 - remainingSeconds / roundDuration;
 
         countdownProgressFill.width((completion * 100) + '%');
         countdownProgressFill.attr('aria-valuenow',
             Math.floor(completion * 100));
         countdownProgressText.text(Math.floor(completion * 100) + "%");
 
-        if (completion < 0.2) {
-            countdownProgressFill.removeClass('progress-bar-success');
+        if (completion < 0.5) {
             countdownProgressFill.removeClass('progress-bar-warning');
-            countdownProgressFill.addClass('progress-bar-danger');
-        } else if (completion < 0.5) {
+            countdownProgressFill.removeClass('progress-bar-danger');
+            countdownProgressFill.addClass('progress-bar-success');
+        } else if (completion < 0.8) {
             countdownProgressFill.removeClass('progress-bar-success');
             countdownProgressFill.removeClass('progress-bar-danger');
             countdownProgressFill.addClass('progress-bar-warning');
         } else {
+            countdownProgressFill.removeClass('progress-bar-success');
             countdownProgressFill.removeClass('progress-bar-warning');
-            countdownProgressFill.removeClass('progress-bar-danger');
-            countdownProgressFill.addClass('progress-bar-success');
+            countdownProgressFill.addClass('progress-bar-danger');
         }
     }
 

--- a/oioioi/clock/templates/clock/navbar-countdown.html
+++ b/oioioi/clock/templates/clock/navbar-countdown.html
@@ -1,11 +1,6 @@
 <div class="countdown-time" id="countdown-time"></div>
 <div id="countdown-progress" class="progress countdown-progress">
-    <div  class="progress-bar"
-          role="progressbar"
-          style="width:100%"
-          aria-valuenow="0"
-          aria-valuemin="0"
-          aria-valuemax="100">
+    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
         <span class="sr-only"></span>
     </div>
 </div>

--- a/oioioi/problems/tests/test_task_archive.py
+++ b/oioioi/problems/tests/test_task_archive.py
@@ -201,7 +201,7 @@ class TestTaskArchive(TestCase):
 
         self.assertNotContains(response, "alert-warning")
         self.assertContains(response, "[16.7%]")
-        self.assertContains(response, "%", count=2)
+        self.assertContains(response, "%", count=1)
 
         html = response.content.decode('utf-8')
 
@@ -219,7 +219,7 @@ class TestTaskArchive(TestCase):
         self.assertNotContains(response, "alert-warning")
         self.assertContains(response, "[0.0%]")
         self.assertContains(response, "[12.5%]")
-        self.assertContains(response, "%", count=3)
+        self.assertContains(response, "%", count=2)
 
         html = response.content.decode('utf-8')
 
@@ -267,4 +267,3 @@ class TestTaskArchive(TestCase):
         test_can_access_with_result(IntegerScore(50), IntegerScore(100))
         test_can_access_with_result(None, IntegerScore(100))
         test_can_access_with_result(IntegerScore(50), None)
-


### PR DESCRIPTION
Reverts 6dbb733 and fixes progress bar's colors.

I'm not sure if reverting this is a good idea. Some people on Szkopul may be used to the current progress bar, but I don't know anyone who prefers how the current progress bar behaves over how it behaved before. I also fixed colors not changing depending on how much time is left until the end of the round.