### PR TITLE
Issue/207

### DIFF
--- a/oioioi/contests/controllers.py
+++ b/oioioi/contests/controllers.py
@@ -286,6 +286,9 @@ class PublicContestRegistrationController(RegistrationController):
     @classmethod
     def anonymous_can_enter_contest(cls):
         return True
+    
+    def allow_login_as_public_name(self):
+        return False
 
     def visible_contests_query(self, request):
         return Q_always_true()

--- a/oioioi/contests/controllers.py
+++ b/oioioi/contests/controllers.py
@@ -286,9 +286,6 @@ class PublicContestRegistrationController(RegistrationController):
     @classmethod
     def anonymous_can_enter_contest(cls):
         return True
-    
-    def allow_login_as_public_name(self):
-        return False
 
     def visible_contests_query(self, request):
         return Q_always_true()

--- a/oioioi/oi/admin.py
+++ b/oioioi/oi/admin.py
@@ -38,6 +38,11 @@ class SchoolAdmin(admin.ModelAdmin):
         'delete_selected',
     )
 
+    def get_list_display(self, request):
+        if request.contest is None:
+            return tuple(ld for ld in self.list_display if ld != 'participants_link')
+        return self.list_display
+
     def participants_link(self, instance):
         return make_html_link(instance.get_participants_url(), _("Participants"))
 

--- a/oioioi/participants/admin.py
+++ b/oioioi/participants/admin.py
@@ -208,7 +208,7 @@ class NoParticipantAdmin(ParticipantAdmin):
 
 
 class ContestDependentParticipantAdmin(admin.InstanceDependentAdmin):
-    default_participant_admin = ParticipantAdmin
+    default_participant_admin = NoParticipantAdmin
 
     def _find_model_admin(self, request, object_id):
         rcontroller = request.contest.controller.registration_controller()

--- a/oioioi/participants/admin.py
+++ b/oioioi/participants/admin.py
@@ -196,6 +196,7 @@ class ParticipantAdmin(admin.ModelAdmin):
 
     extend_round.short_description = _("Extend round")
 
+admin.site.register(Participant, ParticipantAdmin)
 
 class NoParticipantAdmin(ParticipantAdmin):
     def has_add_permission(self, request):

--- a/oioioi/participants/admin.py
+++ b/oioioi/participants/admin.py
@@ -196,8 +196,6 @@ class ParticipantAdmin(admin.ModelAdmin):
 
     extend_round.short_description = _("Extend round")
 
-admin.site.register(Participant, ParticipantAdmin)
-
 class NoParticipantAdmin(ParticipantAdmin):
     def has_add_permission(self, request):
         return False
@@ -210,7 +208,7 @@ class NoParticipantAdmin(ParticipantAdmin):
 
 
 class ContestDependentParticipantAdmin(admin.InstanceDependentAdmin):
-    default_participant_admin = NoParticipantAdmin
+    default_participant_admin = ParticipantAdmin
 
     def _find_model_admin(self, request, object_id):
         rcontroller = request.contest.controller.registration_controller()


### PR DESCRIPTION
Fixes #207

Removed participants column from School superadmin view when no contest is selected. It was causing `Reverse for 'participants_participant_changelist' not found.` error.

_Note: In some contests when trying to navigate into participants change list it is expected to get 403 response_
