### PR TITLE
Notification-sending fixes

### DIFF
--- a/oioioi/problems/controllers.py
+++ b/oioioi/problems/controllers.py
@@ -180,6 +180,10 @@ class ProblemController(RegisteredSubclassesBase, ObjectWithMixins):
                     'oioioi.contests.handlers.call_submission_judged',
                 ),
                 (
+                    'send_notification_submission_judged',
+                    'oioioi.contests.handlers.send_notification_judged',
+                ),
+                (
                     'dump_final_env',
                     'oioioi.evalmgr.handlers.dump_env',
                     dict(message='Finished evaluation'),

--- a/oioioi/programs/controllers.py
+++ b/oioioi/programs/controllers.py
@@ -944,6 +944,15 @@ class ProgrammingContestController(ContestController):
                     'oioioi.contests.handlers.update_submission_score',
                 ),
             )
+            add_before_placeholder(
+                environ,
+                'after_initial_tests',
+                (
+                    'send_notification_initial_tests_judged',
+                    'oioioi.contests.handlers.send_notification_judged',
+                    dict(kind='INITIAL'),
+                ),
+            )
 
     def get_submission_size_limit(self, problem_instance):
         return problem_instance.problem.controller.get_submission_size_limit(

--- a/oioioi/programs/handlers.py
+++ b/oioioi/programs/handlers.py
@@ -579,23 +579,6 @@ def make_report(env, kind='NORMAL', save_scores=True, **kwargs):
         group_report.save()
         group_result['result_id'] = group_report.id
 
-    if kind == 'INITIAL':
-        if submission.user is not None and not env.get('is_rejudge', False):
-            logger.info(
-                "Submission %(submission_id)d by user %(username)s"
-                " for problem %(short_name)s got initial result.",
-                {
-                    'submission_id': submission.pk,
-                    'username': submission.user.username,
-                    'short_name': submission.problem_instance.short_name,
-                },
-                extra={
-                    'notification': 'initial_results',
-                    'user': submission.user,
-                    'submission': submission,
-                },
-            )
-
     return env
 
 

--- a/oioioi/programs/notifications.py
+++ b/oioioi/programs/notifications.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timezone  # pylint: disable=E0611
-
 from django.test import RequestFactory
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext_noop
 
 from oioioi.base.notification import NotificationHandler
@@ -13,7 +12,7 @@ def notification_function_initial_results(arguments):
     request = RequestFactory().get('/', data={'name': u'test'})
     request.user = arguments.user
     request.contest = pi.contest
-    request.timestamp = datetime.now().replace(tzinfo=timezone.utc)
+    request.timestamp = timezone.now()
 
     # Check if any initial result is visible for user
     if not pi.controller.can_see_submission_status(request, arguments.submission):
@@ -54,7 +53,7 @@ def notification_function_submission_judged(arguments):
     request = RequestFactory().get('/', data={'name': u'test'})
     request.user = arguments.user
     request.contest = pi.contest
-    request.timestamp = datetime.now().replace(tzinfo=timezone.utc)
+    request.timestamp = timezone.now()
 
     # Check if the final report is visible to the user
     if not pi.controller.can_see_submission_score(


### PR DESCRIPTION
Resolves #263.
Partially fixes #310 - initial results notifications are now sent for CE submissions, but unfortunately there is also a race condition:
the notification may arrive to the notifications-server in the time window between oioioi generating the "My submissions" page and the user's browser connecting to the notif server.
Then, the browser gets a page without the CE status, but doesn't receive a notification that there was a change.

Additionally, from the CE submissions' commit's message:
```
Move notification-sending logic to a separate function.
This also remedies a rare race condition, in which the user would get
a notification before the updated result is committed to the db.
```