### PR TITLE
Fixed string truncation for TestReport's comment

### DIFF
--- a/oioioi/programs/handlers.py
+++ b/oioioi/programs/handlers.py
@@ -559,9 +559,8 @@ def make_report(env, kind='NORMAL', save_scores=True, **kwargs):
         comment = result.get('result_string', '')
         if comment.lower() in ['ok', 'time limit exceeded']:  # Annoying
             comment = ''
-        test_report.comment = Truncator(comment).chars(
-            TestReport._meta.get_field('comment').max_length
-        )
+        max_comment_length = TestReport._meta.get_field('comment').max_length
+        test_report.comment = (comment[:max_comment_length - 1] + '…') if len(comment) > max_comment_length else comment
         if env.get('save_outputs', False):
             test_report.output_file = filetracker_to_django_file(result['out_file'])
         test_report.save()

--- a/oioioi/testrun/handlers.py
+++ b/oioioi/testrun/handlers.py
@@ -106,9 +106,8 @@ def make_report(env, **kwargs):
 
     testrun_report = TestRunReport(submission_report=submission_report)
     testrun_report.status = env['status']
-    testrun_report.comment = Truncator(comment).chars(
-        TestRunReport._meta.get_field('comment').max_length
-    )
+    max_comment_length = TestRunReport._meta.get_field('comment').max_length
+    testrun_report.comment = (comment[:max_comment_length - 1] + '…') if len(comment) > max_comment_length else comment
     testrun_report.time_used = test_result['time_used']
     testrun_report.test_time_limit = test.get('exec_time_limit')
     testrun_report.output_file = filetracker_to_django_file(test_result['out_file'])


### PR DESCRIPTION
Django's `Truncator(text).chars(n)` seems to [ignore all unicode combining characters](https://github.com/django/django/blob/53fc6ac64976a7693d2272050a03b71e56b16578/django/utils/text.py#L125-L128), resulting in incorrect string truncations.    
For example,
```python
string = 'After\u20e1 trunc, this should be 20 characters...'
temp = Truncator(string).chars(20)
print(len(temp))
```
this outputs:
```
21
```
If we were to remove the unicode symbol, it would correctly output 20. Whether this is truly intended or not eludes me. 

When trying to put a string truncated in such manner into a CharField, it fails to pass the MaxLengthValidator check, as [it internally uses len() for its check](https://github.com/django/django/blob/53fc6ac64976a7693d2272050a03b71e56b16578/django/core/validators.py#L472-L473).

Since Python 3, strings respect Unicode by default, so slices seem to work fine for truncation.