### PR TITLE
Fix ipdnsauth middleware

### DIFF
--- a/oioioi/ipdnsauth/middleware.py
+++ b/oioioi/ipdnsauth/middleware.py
@@ -38,7 +38,7 @@ class IpDnsAuthMiddleware(object):
             return
 
         user = auth.authenticate(request, ip_addr=ip_addr, dns_name=dns_name)
-        if user:
+        if user and not request.user.is_authenticated:
             auth.login(request, user)
 
 


### PR DESCRIPTION
Previously, when IP authentication was enabled, the user was logged in on every request. This caused the csrf token to change on every request, so all forms were failing because of an invalid csrf token. Now the user is only logged in if they weren't logged in previously. 