### PR TITLE
Result percentage changed to a fraction

### DIFF
--- a/oioioi/programs/tests.py
+++ b/oioioi/programs/tests.py
@@ -961,19 +961,19 @@ class TestScorers(TestCase):
     t_results_ok_perc = (
         (
             {'exec_time_limit': 100, 'max_score': 100},
-            {'result_code': 'OK', 'time_used': 0, 'result_percentage': 99},
+            {'result_code': 'OK', 'time_used': 0, 'result_percentage': (99, 1)},
         ),
         (
             {'exec_time_limit': 100, 'max_score': 100},
-            {'result_code': 'OK', 'time_used': 75, 'result_percentage': 50},
+            {'result_code': 'OK', 'time_used': 75, 'result_percentage': (50, 1)},
         ),
         (
             {'exec_time_limit': 100, 'max_score': 100},
-            {'result_code': 'OK', 'time_used': 75, 'result_percentage': 0},
+            {'result_code': 'OK', 'time_used': 75, 'result_percentage': (0, 1)},
         ),
         (
             {'exec_time_limit': 100, 'max_score': 100},
-            {'result_code': 'OK', 'time_used': 99, 'result_percentage': 1},
+            {'result_code': 'OK', 'time_used': 99, 'result_percentage': (1, 1)},
         ),
     )
 

--- a/oioioi/programs/utils.py
+++ b/oioioi/programs/utils.py
@@ -98,8 +98,8 @@ def min_group_scorer(test_results):
 
 def discrete_test_scorer(test, result):
     status = result['result_code']
-    percentage = result.get('result_percentage', 100)
-    max_score = int(ceil(percentage * test['max_score'] / 100.))
+    percentage = result.get('result_percentage', (100, 1))
+    max_score = int(ceil(percentage[0] * test['max_score'] / (100. * percentage[1])))
     score = max_score if status == 'OK' else 0
     return IntegerScore(score), IntegerScore(test['max_score']), status
 
@@ -109,8 +109,8 @@ def threshold_linear_test_scorer(test, result):
     limit = test.get('exec_time_limit', 0)
     used = result.get('time_used', 0)
     status = result['result_code']
-    percentage = result.get('result_percentage', 100)
-    max_score = int(ceil(percentage * test['max_score'] / 100.0))
+    percentage = result.get('result_percentage', (100, 1))
+    max_score = int(ceil(percentage[0] * test['max_score'] / (100. * percentage[1])))
     test_max_score = IntegerScore(test['max_score'])
 
     if status != 'OK':

--- a/oioioi/programs/utils.py
+++ b/oioioi/programs/utils.py
@@ -1,4 +1,5 @@
 import os.path
+from fractions import Fraction
 from math import ceil
 from operator import itemgetter  # pylint: disable=E0611
 
@@ -99,7 +100,7 @@ def min_group_scorer(test_results):
 def discrete_test_scorer(test, result):
     status = result['result_code']
     percentage = result.get('result_percentage', (100, 1))
-    max_score = int(ceil(percentage[0] * test['max_score'] / (100. * percentage[1])))
+    max_score = ceil(Fraction(*percentage) * test['max_score'])
     score = max_score if status == 'OK' else 0
     return IntegerScore(score), IntegerScore(test['max_score']), status
 
@@ -110,7 +111,7 @@ def threshold_linear_test_scorer(test, result):
     used = result.get('time_used', 0)
     status = result['result_code']
     percentage = result.get('result_percentage', (100, 1))
-    max_score = int(ceil(percentage[0] * test['max_score'] / (100. * percentage[1])))
+    max_score = ceil(Fraction(*percentage) * test['max_score'])
     test_max_score = IntegerScore(test['max_score'])
 
     if status != 'OK':

--- a/oioioi/programs/utils.py
+++ b/oioioi/programs/utils.py
@@ -100,7 +100,7 @@ def min_group_scorer(test_results):
 def discrete_test_scorer(test, result):
     status = result['result_code']
     percentage = result.get('result_percentage', (100, 1))
-    max_score = ceil(Fraction(*percentage) * test['max_score'])
+    max_score = ceil(Fraction(*percentage) / 100. * test['max_score'])
     score = max_score if status == 'OK' else 0
     return IntegerScore(score), IntegerScore(test['max_score']), status
 
@@ -111,7 +111,7 @@ def threshold_linear_test_scorer(test, result):
     used = result.get('time_used', 0)
     status = result['result_code']
     percentage = result.get('result_percentage', (100, 1))
-    max_score = ceil(Fraction(*percentage) * test['max_score'])
+    max_score = ceil(Fraction(*percentage) / 100. * test['max_score'])
     test_max_score = IntegerScore(test['max_score'])
 
     if status != 'OK':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # These dependencies need to be installed from external sources,
 # therefore they must be listed here. Moreover, they cannot be listed in
 # setup.py, as pip is not able to install them.
-http://github.com/sio2project/sioworkers/archive/refs/tags/v1.4.3.tar.gz
+http://github.com/sio2project/sioworkers/archive/refs/tags/v1.4.4.tar.gz
 
 -e .


### PR DESCRIPTION
Sioworkers will (https://github.com/sio2project/sioworkers/pull/24) return `result_percentage` as a tuple representing a fraction. The tests will fail until there is a new release of sioworkers with the change.