### PR TITLE
Reduce CSS bundle

### DIFF
--- a/oioioi/contests/static/common/contests.scss
+++ b/oioioi/contests/static/common/contests.scss
@@ -29,6 +29,9 @@ $list-subheader-bgcolor: #eee !default;
 
 .form-list-unstyled {
   ul {
+    // Should be @extend .list-unstyled
+    // but it requires whole scss/style
+    // which increases bundle size dramatically
     padding-left: 0;
     list-style: none;
   }

--- a/oioioi/contests/static/common/contests.scss
+++ b/oioioi/contests/static/common/contests.scss
@@ -1,5 +1,4 @@
 @import "scss/utility";
-@import "scss/style";
 
 $list-grid-column-min-width: 70px !default;
 $list-grid-column-count: 5 !default;
@@ -30,7 +29,8 @@ $list-subheader-bgcolor: #eee !default;
 
 .form-list-unstyled {
   ul {
-    @extend .list-unstyled;
+    padding-left: 0;
+    list-style: none;
   }
 }
 

--- a/oioioi/programs/static/common/programs.scss
+++ b/oioioi/programs/static/common/programs.scss
@@ -1,4 +1,9 @@
-@import "scss/style";
+@import "bootstrap/stylesheets/_functions";
+@import "bootstrap/stylesheets/_variables";
+@import "bootstrap/stylesheets/mixins/_breakpoints";
+@import "bootstrap/stylesheets/mixins/_border-radius";
+@import "bootstrap/stylesheets/mixins/_hover";
+@import "bootstrap/stylesheets/_card";
 
 .test-actions {
   visibility: hidden;
@@ -70,7 +75,7 @@
 
   .linenodiv, .syntax-highlight {
     @extend .card;
-    @extend .bg-light;
+    background-color: #f8f9fa !important;
     padding: ($spacer * 0.5);
   }
 }
@@ -82,7 +87,7 @@
 
   &.line-numbers, &.code {
     @extend .card;
-    @extend .bg-light;
+    background-color: #f8f9fa !important;
     padding: ($spacer * 0.5);
   }
 }

--- a/oioioi/programs/static/common/programs.scss
+++ b/oioioi/programs/static/common/programs.scss
@@ -16,12 +16,14 @@
 }
 
 .table-report {
+
   // In table-report with table-responsive firefox makes new line for
   // test-actions used with float-right on sm display.
   // This is a workaround for this.
   .fix-float-right {
     white-space: normal !important;
   }
+
   .group-score {
     vertical-align: middle;
   }
@@ -38,21 +40,25 @@
 }
 
 .syntax-highlighttable {
+
   // Collapse the border between line numbers and code.
   // (...) (...) -> (...|...)
   td.linenos {
-    & > .linenodiv {
+    &>.linenodiv {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       border-right: none;
     }
+
     padding-right: 0;
   }
+
   td.code {
-    & > .syntax-highlight {
+    &>.syntax-highlight {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }
+
     padding-left: 0
   }
 
@@ -73,8 +79,12 @@
     margin-bottom: 0;
   }
 
-  .linenodiv, .syntax-highlight {
+  .linenodiv,
+  .syntax-highlight {
     @extend .card;
+    // Should be @extend .bg-light
+    // but it requires whole bootstrap to be included
+    // which increases bundle size dramatically
     background-color: #f8f9fa !important;
     padding: ($spacer * 0.5);
   }
@@ -85,8 +95,12 @@
     margin-bottom: 0;
   }
 
-  &.line-numbers, &.code {
+  &.line-numbers,
+  &.code {
     @extend .card;
+    // Should be @extend .bg-light
+    // but it requires whole bootstrap to be included
+    // which increases bundle size dramatically
     background-color: #f8f9fa !important;
     padding: ($spacer * 0.5);
   }

--- a/oioioi/programs/static/common/programs.scss
+++ b/oioioi/programs/static/common/programs.scss
@@ -48,7 +48,6 @@
     }
     padding-right: 0;
   }
-
   td.code {
     & > .syntax-highlight {
       border-top-left-radius: 0;

--- a/oioioi/programs/static/common/programs.scss
+++ b/oioioi/programs/static/common/programs.scss
@@ -16,14 +16,12 @@
 }
 
 .table-report {
-
   // In table-report with table-responsive firefox makes new line for
   // test-actions used with float-right on sm display.
   // This is a workaround for this.
   .fix-float-right {
     white-space: normal !important;
   }
-
   .group-score {
     vertical-align: middle;
   }
@@ -40,25 +38,22 @@
 }
 
 .syntax-highlighttable {
-
   // Collapse the border between line numbers and code.
   // (...) (...) -> (...|...)
   td.linenos {
-    &>.linenodiv {
+    & > .linenodiv {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       border-right: none;
     }
-
     padding-right: 0;
   }
 
   td.code {
-    &>.syntax-highlight {
+    & > .syntax-highlight {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }
-
     padding-left: 0
   }
 
@@ -79,8 +74,7 @@
     margin-bottom: 0;
   }
 
-  .linenodiv,
-  .syntax-highlight {
+  .linenodiv, .syntax-highlight {
     @extend .card;
     // Should be @extend .bg-light
     // but it requires whole bootstrap to be included
@@ -95,8 +89,7 @@
     margin-bottom: 0;
   }
 
-  &.line-numbers,
-  &.code {
+  &.line-numbers, &.code {
     @extend .card;
     // Should be @extend .bg-light
     // but it requires whole bootstrap to be included

--- a/oioioi/programs/static/common/submission-diff.scss
+++ b/oioioi/programs/static/common/submission-diff.scss
@@ -1,5 +1,3 @@
-@import "scss/style";
-
 $left-diff-text: #b94a48 !default;
 $left-diff-background: #f2dede !default;
 $right-diff-text: #468847 !default;


### PR DESCRIPTION
The main cause of CSS bundle being so big is that `scss/style` is imported several times in different files and isn't deduplicated by django. Fixed by replacing that import with one that includes only specific, necessary file. This reduced CSS bundle from around 1MB to 350kB.