### PR TITLE
Attachments visibility follow-up

### DIFF
--- a/oioioi/acm/controllers.py
+++ b/oioioi/acm/controllers.py
@@ -178,9 +178,9 @@ class ACMContestController(ProgrammingContestController):
     def ranking_controller(self):
         return ACMRankingController(self.contest)
 
-    def can_see_round(self, request_or_context, round):
+    def can_see_round(self, request_or_context, round, no_admin=False):
         context = self.make_context(request_or_context)
-        if context.is_admin:
+        if not no_admin and context.is_admin:
             return True
         rtimes = self.get_round_times(request_or_context, round)
         return rtimes.is_active(context.timestamp)

--- a/oioioi/base/utils/__init__.py
+++ b/oioioi/base/utils/__init__.py
@@ -365,6 +365,24 @@ def request_cached(fn):
     return cacher
 
 
+def request_cached_complex(fn):
+    """Adds per-request caching for functions which operate on more than a request.
+    Additional arguments and keyword arguments passed to the wrapped function
+    must be hashable, which generally means that their type must be immutable.
+    """
+
+    @functools.wraps(fn)
+    def cacher(request, *args, **kwargs):
+        if not hasattr(request, '_cache'):
+            setattr(request, '_cache', {})
+        key = (fn, tuple(args), tuple(kwargs.items()))
+        if key not in request._cache:
+            request._cache[key] = fn(request, *args, **kwargs)
+        return request._cache[key]
+
+    return cacher
+
+
 # Generating HTML
 
 

--- a/oioioi/contests/attachment_registration.py
+++ b/oioioi/contests/attachment_registration.py
@@ -17,7 +17,7 @@ class AttachmentRegistry(object):
         :Parameters:
             Function that takes elements from `**kwargs` as arguments and
             returns dictionary containing following keys: `category`,
-            `name`, `description`, `link`, `pub_date`.
+            `name`, `description`, `link`, `pub_date`, `admin_only`.
         """
         if attachment_generator is not None:
             self._registry.register(attachment_generator, order)

--- a/oioioi/contests/controllers.py
+++ b/oioioi/contests/controllers.py
@@ -511,7 +511,7 @@ class ContestController(RegisteredSubclassesBase, ObjectWithMixins):
 
         return sorted(queryset, key=sort_key)
 
-    def can_see_round(self, request_or_context, round):
+    def can_see_round(self, request_or_context, round, no_admin=False):
         """Determines if the current user is allowed to see the given round.
 
         If not, everything connected with this round will be hidden.
@@ -519,7 +519,7 @@ class ContestController(RegisteredSubclassesBase, ObjectWithMixins):
         The default implementation checks if the round is not in the future.
         """
         context = self.make_context(request_or_context)
-        if context.is_admin:
+        if not no_admin and context.is_admin:
             return True
         rtimes = self.get_round_times(request_or_context, round)
         return not rtimes.is_future(context.timestamp)
@@ -550,7 +550,7 @@ class ContestController(RegisteredSubclassesBase, ObjectWithMixins):
     def default_can_see_ranking(self, request_or_context):
         return True
 
-    def can_see_problem(self, request_or_context, problem_instance):
+    def can_see_problem(self, request_or_context, problem_instance, no_admin=False):
         """Determines if the current user is allowed to see the given problem.
 
         If not, the problem will be hidden from all lists, so that its name
@@ -562,9 +562,11 @@ class ContestController(RegisteredSubclassesBase, ObjectWithMixins):
         context = self.make_context(request_or_context)
         if not problem_instance.round:
             return False
-        if context.is_admin:
+        if not no_admin and context.is_admin:
             return True
-        return self.can_see_round(request_or_context, problem_instance.round)
+        return self.can_see_round(
+            request_or_context, problem_instance.round, no_admin=no_admin
+        )
 
     def can_see_statement(self, request_or_context, problem_instance):
         """Determines if the current user is allowed to see the statement for
@@ -987,7 +989,7 @@ class PastRoundsHiddenContestControllerMixin(object):
     Do not use it with overlapping rounds.
     """
 
-    def can_see_round(self, request_or_context, round):
+    def can_see_round(self, request_or_context, round, no_admin=False):
         """Decides whether the given round should be shown for the given user.
         The algorithm is as follows:
 
@@ -1006,7 +1008,7 @@ class PastRoundsHiddenContestControllerMixin(object):
              1. Otherwise the decision is made by the superclass method.
         """
         context = self.make_context(request_or_context)
-        if context.is_admin:
+        if not no_admin and context.is_admin:
             return True
 
         rtimes = self.get_round_times(None, round)
@@ -1022,7 +1024,7 @@ class PastRoundsHiddenContestControllerMixin(object):
                 return False
 
         return super(PastRoundsHiddenContestControllerMixin, self).can_see_round(
-            request_or_context, round
+            request_or_context, round, no_admin
         )
 
 

--- a/oioioi/contests/tests/tests.py
+++ b/oioioi/contests/tests/tests.py
@@ -1402,169 +1402,154 @@ class TestAttachments(TestCase, TestStreamingMixin):
     ]
 
     def test_attachments(self):
-        contest = Contest.objects.get()
-        problem = Problem.objects.get()
-        ca = ContestAttachment(
-            contest=contest,
-            description='contest-attachment',
-            content=ContentFile(b'content-of-conatt', name='conatt.txt'),
-        )
-        ca.save()
-        pa = ProblemAttachment(
-            problem=problem,
-            description='problem-attachment',
-            content=ContentFile(b'content-of-probatt', name='probatt.txt'),
-        )
-        pa.save()
-        round = Round.objects.get(pk=1)
-        ra = ContestAttachment(
-            contest=contest,
-            description='round-attachment',
-            content=ContentFile(b'content-of-roundatt', name='roundatt.txt'),
-            round=round,
-        )
-        ra.save()
+        # Possible attachments:
+        #  - ContestAttachent without round: pub_date == None or not
+        #  - ProblemAttachment (has round and no pub_date)
+        #  - ContestAttachent with round: pub_date == None or before or after
 
-        self.assertTrue(self.client.login(username='test_user'))
-        response = self.client.get(
-            reverse('contest_files', kwargs={'contest_id': contest.id})
-        )
-        self.assertEqual(response.status_code, 200)
-        for part in [
-            'contest-attachment',
+        # The round starts at 2011.07.31-20:57:58
+        def get_time(hour):
+            return datetime(2011, 7, 31, hour, 0, 0, tzinfo=timezone.utc)
+
+        # The attachemnts are in (attachment, content, name) tuples.
+        contest = Contest.objects.get()
+        ca = (
+            ContestAttachment.objects.create(
+                contest=contest,
+                description='contest-attachment-simple',
+                content=ContentFile(b'content-of-conatt-simple', name='conatt.txt'),
+            ),
+            b'content-of-conatt-simple',
             'conatt.txt',
-            'problem-attachment',
+        )
+        cb = (
+            ContestAttachment.objects.create(
+                contest=contest,
+                description='contest-attachment-pub-date',
+                content=ContentFile(b'content-of-conatt-pub', name='conatt-pub.txt'),
+                pub_date=get_time(19),
+            ),
+            b'content-of-conatt-pub',
+            'conatt-pub.txt',
+        )
+        problem = Problem.objects.get()
+        pa = (
+            ProblemAttachment.objects.create(
+                problem=problem,
+                description='problem-attachment',
+                content=ContentFile(b'content-of-probatt', name='probatt.txt'),
+            ),
+            b'content-of-probatt',
             'probatt.txt',
-            'round-attachment',
+        )
+        round = Round.objects.get(pk=1)
+        ra = (
+            ContestAttachment.objects.create(
+                contest=contest,
+                description='round-attachment',
+                content=ContentFile(b'content-of-roundatt-simple', name='roundatt.txt'),
+                round=round,
+            ),
+            b'content-of-roundatt-simple',
             'roundatt.txt',
-        ]:
-            self.assertContains(response, part)
-        response = self.client.get(
-            reverse(
-                'contest_attachment',
-                kwargs={'contest_id': contest.id, 'attachment_id': ca.id},
-            )
         )
-        self.assertStreamingEqual(response, b'content-of-conatt')
-        response = self.client.get(
-            reverse(
-                'problem_attachment',
-                kwargs={'contest_id': contest.id, 'attachment_id': pa.id},
-            )
+        ra[0].save()
+        rb = (
+            ContestAttachment.objects.create(
+                contest=contest,
+                description='round-attachment-pub-date-before',
+                content=ContentFile(b'content-of-roundatt-before', name='roundatt-before.txt'),
+                round=round,
+                pub_date=get_time(19),
+            ),
+            b'content-of-roundatt-before',
+            'roundatt-before.txt',
         )
-        self.assertStreamingEqual(response, b'content-of-probatt')
-        response = self.client.get(
-            reverse(
-                'contest_attachment',
-                kwargs={'contest_id': contest.id, 'attachment_id': ra.id},
-            )
+        rc = (
+            ContestAttachment.objects.create(
+                contest=contest,
+                description='round-attachment-pub-date-after',
+                content=ContentFile(b'content-of-roundatt-after', name='roundatt-after.txt'),
+                round=round,
+                pub_date=get_time(22),
+            ),
+            b'content-of-roundatt-after',
+            'roundatt-after.txt',
         )
-        self.assertStreamingEqual(response, b'content-of-roundatt')
 
-        with fake_time(datetime(2011, 7, 10, tzinfo=timezone.utc)):
-            response = self.client.get(
-                reverse('contest_files', kwargs={'contest_id': contest.id})
-            )
+        def get_attachment_urlpattern_name(att):
+            if type(att) is ContestAttachment:
+                return 'contest_attachment'
+            assert type(att) is ProblemAttachment
+            return 'problem_attachment'
+
+        def check(visible, invisible):
+            list_url = reverse('contest_files', kwargs={'contest_id': contest.id})
+            self.assertTrue(self.client.login(username='test_user'))
+
+            # File list
+            response = self.client.get(list_url)
             self.assertEqual(response.status_code, 200)
-            for part in ['contest-attachment', 'conatt.txt']:
-                self.assertContains(response, part)
-            for part in [
-                'problem-attachment',
-                'probatt.txt',
-                'round-attachment',
-                'roundatt.txt',
-            ]:
-                self.assertNotContains(response, part)
-            response = self.client.get(
-                reverse(
-                    'contest_attachment',
-                    kwargs={'contest_id': contest.id, 'attachment_id': ca.id},
-                )
-            )
-            self.assertStreamingEqual(response, b'content-of-conatt')
-            check_not_accessible(
-                self,
-                'problem_attachment',
-                kwargs={'contest_id': contest.id, 'attachment_id': pa.id},
-            )
-            check_not_accessible(
-                self,
-                'contest_attachment',
-                kwargs={'contest_id': contest.id, 'attachment_id': ra.id},
-            )
+            for (att, content, name) in visible:
+                self.assertContains(response, name)
+                self.assertContains(response, att.description)
+            for (att, content, name) in invisible:
+                self.assertNotContains(response, name)
+                self.assertNotContains(response, att.description)
+            for f in response.context['files']:
+                self.assertEqual(f['admin_only'], False)
 
-    def test_pub_date(self):
-        contest = Contest.objects.get()
-        ca = ContestAttachment(
-            contest=contest,
-            description='contest-attachment',
-            content=ContentFile(b'content-null', name='conatt-null-date.txt'),
-            pub_date=None,
-        )
-        ca.save()
-        cb = ContestAttachment(
-            contest=contest,
-            description='contest-attachment',
-            content=ContentFile(b'content-visible', name='conatt-visible.txt'),
-            pub_date=datetime(2011, 7, 10, 0, 0, 0, tzinfo=timezone.utc),
-        )
-        cb.save()
-        cc = ContestAttachment(
-            contest=contest,
-            description='contest-attachment',
-            content=ContentFile(b'content-hidden', name='conatt-hidden.txt'),
-            pub_date=datetime(2011, 7, 10, 1, 0, 0, tzinfo=timezone.utc),
-        )
-        cc.save()
-
-        def check_visibility(*should_be_visible):
-            response = self.client.get(
-                reverse('contest_files', kwargs={'contest_id': contest.id})
-            )
-            for name in [
-                'conatt-null-date.txt',
-                'conatt-visible.txt',
-                'conatt-hidden.txt',
-            ]:
-                if name in should_be_visible:
-                    self.assertContains(response, name)
-                else:
-                    self.assertNotContains(response, name)
-
-        def check_accessibility(should_be_accesible, should_not_be_accesible):
-            for (id, content) in should_be_accesible:
+            # Actual accessibility
+            for (att, content, name) in visible:
                 response = self.client.get(
                     reverse(
-                        'contest_attachment',
-                        kwargs={'contest_id': contest.id, 'attachment_id': id},
+                        get_attachment_urlpattern_name(att),
+                        kwargs={'contest_id': contest.id, 'attachment_id': att.id},
                     )
                 )
                 self.assertStreamingEqual(response, content)
-            for id in should_not_be_accesible:
+            for (att, content, name) in invisible:
                 check_not_accessible(
                     self,
-                    'contest_attachment',
-                    kwargs={'contest_id': contest.id, 'attachment_id': id},
+                    get_attachment_urlpattern_name(att),
+                    kwargs={'contest_id': contest.id, 'attachment_id': att.id},
                 )
 
-        with fake_time(datetime(2011, 7, 10, 0, 30, 0, tzinfo=timezone.utc)):
-            self.assertTrue(self.client.login(username='test_user'))
-            check_visibility('conatt-null-date.txt', 'conatt-visible.txt')
-            check_accessibility(
-                [(ca.id, b'content-null'), (cb.id, b'content-visible')], [cc.id]
-            )
+            # File list again, but as an admin
             self.assertTrue(self.client.login(username='test_admin'))
-            check_visibility(
-                'conatt-null-date.txt', 'conatt-visible.txt', 'conatt-hidden.txt'
-            )
-            check_accessibility(
-                [
-                    (ca.id, b'content-null'),
-                    (cb.id, b'content-visible'),
-                    (cc.id, b'content-hidden'),
-                ],
-                [],
-            )
+            response = self.client.get(list_url)
+            self.assertEqual(response.status_code, 200)
+            for (att, content, name) in visible + invisible:
+                self.assertContains(response, name)
+                self.assertContains(response, att.description)
+            invisible_names = set([f[2] for f in invisible])
+            for f in response.context['files']:
+                self.assertEqual(f['admin_only'], f['name'] in invisible_names)
+
+            # Actual accessibility as an admin
+            for (att, content, name) in visible + invisible:
+                response = self.client.get(
+                    reverse(
+                        get_attachment_urlpattern_name(att),
+                        kwargs={'contest_id': contest.id, 'attachment_id': att.id},
+                    )
+                )
+                self.assertStreamingEqual(response, content)
+
+        # Now, therefore far later than all of the dates
+        check([ca, cb, pa, ra, rb, rc], [])
+        # Before all dates
+        with fake_time(get_time(18)):
+            check([ca,], [cb, pa, ra, rb, rc])
+        # Before the round start, but after the pub_dates before it
+        with fake_time(get_time(20)):
+            check([ca, cb], [pa, ra, rb, rc])
+        # After the round start, but before the last pub_date
+        with fake_time(get_time(21)):
+            check([ca, cb, pa, ra, rb], [rc])
+        # After the last pub_date
+        with fake_time(get_time(23)):
+            check([ca, cb, pa, ra, rb, rc], [])
 
 
 class TestRoundExtension(TestCase, SubmitFileMixin):

--- a/oioioi/contests/utils.py
+++ b/oioioi/contests/utils.py
@@ -8,7 +8,7 @@ from django.utils.module_loading import import_string
 from pytz import UTC
 
 from oioioi.base.permissions import make_request_condition
-from oioioi.base.utils import request_cached
+from oioioi.base.utils import request_cached, request_cached_complex
 from oioioi.base.utils.public_message import get_public_message
 from oioioi.base.utils.query_helpers import Q_always_false
 from oioioi.contests.models import (
@@ -229,22 +229,26 @@ def submittable_problem_instances(request):
     return [pi for pi in queryset if controller.can_submit(request, pi)]
 
 
-@request_cached
-def visible_problem_instances(request):
+@request_cached_complex
+def visible_problem_instances(request, no_admin=False):
     controller = request.contest.controller
     queryset = (
         ProblemInstance.objects.filter(contest=request.contest)
         .select_related('problem')
         .prefetch_related('round')
     )
-    return [pi for pi in queryset if controller.can_see_problem(request, pi)]
+    return [pi for pi in queryset if controller.can_see_problem(
+        request, pi, no_admin=no_admin,
+    )]
 
 
-@request_cached
-def visible_rounds(request):
+@request_cached_complex
+def visible_rounds(request, no_admin=False):
     controller = request.contest.controller
     queryset = Round.objects.filter(contest=request.contest)
-    return [r for r in queryset if controller.can_see_round(request, r)]
+    return [r for r in queryset if controller.can_see_round(
+        request, r, no_admin=no_admin,
+    )]
 
 
 def aggregate_statuses(statuses):

--- a/oioioi/problems/problem_site.py
+++ b/oioioi/problems/problem_site.py
@@ -150,6 +150,7 @@ def problem_site_files(request, problem):
                         'attachment_id': f.id,
                     },
                 ),
+                'admin_only': False,
             }
             for f in files_qs
         ],

--- a/oioioi/problems/templates/problems/files.html
+++ b/oioioi/problems/templates/problems/files.html
@@ -20,7 +20,7 @@
                 </thead>
                 <tbody>
                     {% for file in files %}
-                        <tr {% if not file.pub_date or file.pub_date > request.timestamp %} class="text-muted" {% endif %}>
+                        <tr {% if file.admin_only %} class="text-muted" {% endif %}>
                             {% if add_category_field %}
                                 <td>{{ file.category }}</td>
                             {% endif %}

--- a/oioioi/testspackages/views.py
+++ b/oioioi/testspackages/views.py
@@ -14,11 +14,9 @@ from oioioi.contests.attachment_registration import (
 from oioioi.contests.utils import (
     can_enter_contest,
     contest_exists,
-    is_contest_admin,
     is_contest_basicadmin,
     visible_problem_instances,
 )
-from oioioi.contests.models import ProblemInstance
 from oioioi.filetracker.utils import stream_file
 from oioioi.problems.utils import can_admin_problem
 from oioioi.testspackages.models import TestsPackage
@@ -91,13 +89,8 @@ def get_tests_package_file(test_package):
 @enforce_condition(not_anonymous & contest_exists & can_enter_contest)
 def test_view(request, package_id):
     tp = get_object_or_404(TestsPackage, id=package_id)
-    # Check if TestPackage is attached to requested contest
-    if not ProblemInstance.objects.filter(
-        problem=tp.problem, contest=request.contest
-    ).exists():
+    if all(tp != i[0] for i in visible_tests_packages(request)):
         raise Http404
-    if not is_contest_admin(request) and not tp.is_visible(request.timestamp):
-        raise PermissionDenied
     return get_tests_package_file(tp)
 
 

--- a/oioioi/testspackages/views.py
+++ b/oioioi/testspackages/views.py
@@ -27,21 +27,31 @@ from oioioi.testspackages.models import TestsPackage
 @request_cached
 def visible_tests_packages(request):
     problems = [pi.problem for pi in visible_problem_instances(request)]
+    is_admin = is_contest_basicadmin(request)
+    if is_admin:
+        problem_ids_without_admin = {
+            pi.problem_id for pi in visible_problem_instances(
+                request,
+                no_admin=True,
+            )
+        }
+    else:
+        problem_ids_without_admin = {p.id for p in problems}
     tests_packages = TestsPackage.objects.filter(problem__in=problems)
-    return [
-        tp
-        for tp in tests_packages
-        if tp.package is not None and (
-            is_contest_basicadmin(request) or
-            tp.is_visible(request.timestamp)
-        )
-    ]
+    visible_packages = [] # list of (test package, is for admins only) tuples
+    for tp in tests_packages:
+        visible = tp.is_visible(request.timestamp)
+        if tp.package is None or (not visible and not is_admin):
+            continue
+        admin_only = tp.problem_id not in problem_ids_without_admin or not visible
+        visible_packages.append((tp, admin_only))
+    return visible_packages
 
 
 @attachment_registry.register
 def get_tests(request):
     tests = []
-    for tp in visible_tests_packages(request):
+    for tp, admin_only in visible_tests_packages(request):
         t = {
             'category': tp.problem,
             'name': os.path.basename(tp.name) + '.zip',
@@ -50,6 +60,7 @@ def get_tests(request):
                 'test', kwargs={'contest_id': request.contest.id, 'package_id': tp.id}
             ),
             'pub_date': tp.publish_date,
+            'admin_only': admin_only,
         }
         tests.append(t)
     return tests


### PR DESCRIPTION
This is a follow-up of https://github.com/sio2project/oioioi/pull/233, by which only testspackages were handled somewhat decently, causing e.g. some attachments to appear greyed-out to normal users, for which I am very sorry.

The 'admin_only' dict field has been added to the attachments, as the pub_date alone isn't enough to determine whether the attachment would be visible if the user wasn't an admin.
One example is a ContestAttachment for a round that starts in the future, not to mention the inconsistent meaning of an empty publication date (for TestsPackages it means "never visible", for others "always visible").
The new field/logic should also be useful for the "page with important stats for Jury".

While reworking the related tests, I discovered a bug in the visibility check for downloading a testspackage and fixed it in the second commit.
Here are the steps to reproduce it:
1. Have a clean sio2 instance with a contest.
2. Create a ProblemInstance in a round that starts *in the future*.
3. Make a TestsPackage for that ProblemInstance with a publish_date *in the past* or set to nothing.
4. The package is available at `/c/{contest.id}/tests/1`, where 1 should be the TestsPackage's id.