### PR TITLE
Print oi module ImportError in debug mode

### DIFF
--- a/oioioi/base/models.py
+++ b/oioioi/base/models.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import sys
 from importlib import import_module
 
 import django.dispatch
@@ -22,7 +23,9 @@ for app in settings.INSTALLED_APPS:
             # Controllers should be imported at startup, because they register
             # mixins
             import_module(app + '.controllers')
-        except ImportError:
+        except ImportError as e:
+            if settings.DEBUG:
+                print(e, file=sys.stderr)
             pass
 
 import logging

--- a/oioioi/base/models.py
+++ b/oioioi/base/models.py
@@ -26,7 +26,6 @@ for app in settings.INSTALLED_APPS:
         except ImportError as e:
             if settings.DEBUG:
                 print(e, file=sys.stderr)
-            pass
 
 import logging
 

--- a/oioioi/base/models.py
+++ b/oioioi/base/models.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import sys
-from importlib import import_module
 
 import django.dispatch
 from django.conf import settings
@@ -16,16 +15,6 @@ from oioioi.contests.models import Contest
 # Check if database settings are correct.
 setup_check()
 captcha_check()
-
-for app in settings.INSTALLED_APPS:
-    if app.startswith('oioioi.'):
-        try:
-            # Controllers should be imported at startup, because they register
-            # mixins
-            import_module(app + '.controllers')
-        except ImportError as e:
-            if settings.DEBUG:
-                print(e, file=sys.stderr)
 
 import logging
 

--- a/oioioi/contests/urls.py
+++ b/oioioi/contests/urls.py
@@ -222,6 +222,8 @@ for app in settings.INSTALLED_APPS:
             # patterns defined in the global urls.py are an exception
             if hasattr(urls_module, 'urlpatterns'):
                 neutral_patterns += getattr(urls_module, 'urlpatterns')
+        except ModuleNotFoundError:
+            pass
         except ImportError as e:
             if settings.DEBUG:
                 print(e, file=sys.stderr)

--- a/oioioi/contests/urls.py
+++ b/oioioi/contests/urls.py
@@ -1,3 +1,4 @@
+import sys
 from importlib import import_module
 
 from django.conf import settings
@@ -221,7 +222,9 @@ for app in settings.INSTALLED_APPS:
             # patterns defined in the global urls.py are an exception
             if hasattr(urls_module, 'urlpatterns'):
                 neutral_patterns += getattr(urls_module, 'urlpatterns')
-        except ImportError:
+        except ImportError as e:
+            if settings.DEBUG:
+                print(e, file=sys.stderr)
             pass
 
 # We actually use make_patterns here, but we don't pass the globs, because

--- a/oioioi/contests/urls.py
+++ b/oioioi/contests/urls.py
@@ -225,7 +225,6 @@ for app in settings.INSTALLED_APPS:
         except ImportError as e:
             if settings.DEBUG:
                 print(e, file=sys.stderr)
-            pass
 
 # We actually use make_patterns here, but we don't pass the globs, because
 # the algorithm in oioioi.urls has yet to capture all urls, including ours.

--- a/oioioi/urls.py
+++ b/oioioi/urls.py
@@ -1,3 +1,4 @@
+import sys
 from importlib import import_module
 
 from django.conf import settings
@@ -44,8 +45,9 @@ for app in settings.INSTALLED_APPS:
             urls_module = import_module(app + '.urls')
             if hasattr(urls_module, 'urlpatterns'):
                 urlpatterns += getattr(urls_module, 'urlpatterns')
-        except ImportError:
-            pass
+        except ImportError as e:
+            if settings.DEBUG:
+                print(e, file=sys.stderr)
 
 urlpatterns.extend(
     [

--- a/oioioi/urls.py
+++ b/oioioi/urls.py
@@ -36,18 +36,27 @@ if settings.DEBUG:
         re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ]
 
+def try_to_import_module(name):
+    try:
+        return import_module(name)
+    except ModuleNotFoundError:
+        pass
+    except ImportError as e:
+        if settings.DEBUG:
+            print(e, file=sys.stderr)
+    return None
+
 for app in settings.INSTALLED_APPS:
     if app.startswith('oioioi.'):
-        try:
-            # Django imports views lazily, and since there are some decorators
-            # that have to run, all views need to be imported at startup
-            import_module(app + '.views')
-            urls_module = import_module(app + '.urls')
-            if hasattr(urls_module, 'urlpatterns'):
-                urlpatterns += getattr(urls_module, 'urlpatterns')
-        except ImportError as e:
-            if settings.DEBUG:
-                print(e, file=sys.stderr)
+        # Django imports views lazily, and since there are some decorators
+        # that have to run, all views need to be imported at startup.
+        try_to_import_module(app + '.views')
+        # Controllers should be imported at startup, because they register
+        # mixins.
+        try_to_import_module(app + '.controllers')
+        urls_module = try_to_import_module(app + '.urls')
+        if hasattr(urls_module, 'urlpatterns'):
+            urlpatterns += getattr(urls_module, 'urlpatterns')
 
 urlpatterns.extend(
     [


### PR DESCRIPTION
Two days ago I wasted 30 minutes trying to figure out why my URL doesn't register in urls.py, turned out to be an error somewhere else in views.py and there was no indication of it.

Hopefully this will be helpful to someone in the future as it would've been for me at that moment.

Prints only the exception message instead of the whole stack as that would've been annoying in some setups (already this prints about 20 error lines on stock sio2 setup)