### PR TITLE
Consistent new message formatting for new questions

### DIFF
--- a/oioioi/questions/templates/questions/message.html
+++ b/oioioi/questions/templates/questions/message.html
@@ -49,7 +49,7 @@
 {% if is_admin %}
 <script type="text/javascript">
     var alertText = '<div class="alert alert-info" id="alert_%id%">' +
-        '<h4>{% trans "New answer available" %}' + '</h4><p>' + '%content%' + '</p>' +
+        '<h4>{% trans "New answer available" %}' + '</h4><p class="oioioi-message__body">' + '%content%' + '</p>' +
         '<p><button type="button" class="btn btn-info" onclick="new_answer_reload_page()">' +
         '{% trans "Reload page" %}' + '</button> ' +
         '<button type="button" class="btn btn-info" onclick="dismissNewMessageAlert(%id%)">' +


### PR DESCRIPTION
ATM new questions ignore newlines, which is inconsistent and can make the incoming new message hard to read.

Note: I'm not sure if this violates BEM naming conventions, [some claim it doesn't](https://en.bem.info/forum/43/). If it does I'm not against nesting it in `.oioioi-message`, since that class when by itself currently has no styling: https://github.com/sio2project/oioioi/blob/0fcee5ec26341c8820c71d7ea4f104f00e6d7e6f/oioioi/questions/static/common/messages.scss#L3-L41