### PR TITLE
Fix copying code to clipboard on http

### DIFF
--- a/oioioi/programs/static/common/clipboard.js
+++ b/oioioi/programs/static/common/clipboard.js
@@ -1,10 +1,38 @@
+function successCopy() {
+    const button = document.getElementById("cpy_btn");
+    button.classList.remove("btn-outline-secondary");
+    button.classList.add("btn-success");
+    button.textContent = gettext("Copied!");
+}
+
+function failCopy() {
+    alert(gettext("Unable to copy Code"));
+}
+
 function copyCodeToClipboard() {
-    navigator.clipboard.writeText(document.getElementById("raw_source").textContent).then(function() {
-        const button = document.getElementById("cpy_btn");
-        button.classList.remove("btn-outline-secondary");
-        button.classList.add("btn-success");
-        button.textContent = gettext("Copied!");
-    }, function() {
-        alert(gettext("Unable to copy Code"));
-    });
+    if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(
+            document.getElementById("raw_source").textContent
+        ).then(
+            successCopy,
+            failCopy
+        );
+    }
+    else {
+        const textArea = document.createElement("textarea");
+        // Hide the textArea from view
+        textArea.style.position = "absolute";
+        textArea.style.left = "-999999px";
+        textArea.value = document.getElementById("raw_source").textContent;
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+            document.execCommand("copy");
+            successCopy();
+        } catch (err) {
+            failCopy();
+        }
+        document.body.removeChild(textArea);
+    }
 }


### PR DESCRIPTION
Copying to clipboard with `navigator.clipboard` is not allowed when using http. This PR fixes this using `document.execCommand()`. Although this function has been deprecated, [most browsers still support it](https://caniuse.com/mdn-api_document_execcommand). 
