### PR TITLE
Fix search and filtering in SubmissionAdmin

### DIFF
--- a/oioioi/contests/admin.py
+++ b/oioioi/contests/admin.py
@@ -685,6 +685,7 @@ class SubmissionAdmin(admin.ModelAdmin):
         'user__last_name',
         'problem_instance__problem__legacy_name',
         'problem_instance__short_name',
+        'problem_instance__problem__names__name',
     ]
 
     class Media:
@@ -729,23 +730,6 @@ class SubmissionAdmin(admin.ModelAdmin):
     def get_urls(self):
         urls = [re_path(r'^rejudge/$', self.rejudge_view)]
         return urls + super(SubmissionAdmin, self).get_urls()
-
-    def get_search_results(self, request, queryset, search_term):
-        matched_problems = set(
-            problem_name.problem.pk
-            for problem_name in ProblemName.objects.filter(name__icontains=search_term)
-        )
-        queryset, _ = super(SubmissionAdmin, self).get_search_results(
-            request, queryset, search_term
-        )
-        contest_filtered = self.get_queryset(request)
-        queryset |= contest_filtered.filter(
-            problem_instance__problem__in=matched_problems
-        )
-
-        queryset = queryset.order_by('-id')
-
-        return queryset, True
 
     def rejudge_view(self, request):
         tests = request.POST.getlist('tests', [])


### PR DESCRIPTION
This fixes a bug where the submission queryset contained objects matching a search term *or* other filters, not *and*.
It was caused by using `self.get_queryset(request)` instead of the `queryset` passed in args, which sometimes bypassed user-selected filters.

Steps to reproduce:
1. Add two problems with different names to a contest, let's say "abc" and "tst"
2. Add ProblemName objects to "abc", e.g. "aaa"
3. Go to Contest Administration -> Submissions, filter "by problem" for "tst"
4. Search for "aaa"
5. See submissions from "abc", despite the filter for "tst"