### PR TITLE
Hide problems field from OriginTag's and OriginInfoValue's admin view

### DIFF
--- a/oioioi/problems/admin.py
+++ b/oioioi/problems/admin.py
@@ -296,6 +296,7 @@ class OriginTagLocalizationInline(BaseTagLocalizationInline):
 
 class OriginTagAdmin(BaseTagAdmin):
     inlines = (OriginTagLocalizationInline,)
+    exclude = ['problems']
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         _update_queryset_if_problems(db_field, **kwargs)
@@ -336,6 +337,7 @@ class OriginInfoValueLocalizationInline(BaseTagLocalizationInline):
 class OriginInfoValueAdmin(admin.ModelAdmin):
     form = OriginInfoValueForm
     inlines = (OriginInfoValueLocalizationInline,)
+    exclude = ['problems']
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         _update_queryset_if_problems(db_field, **kwargs)

--- a/oioioi/problems/forms.py
+++ b/oioioi/problems/forms.py
@@ -184,10 +184,11 @@ class OriginInfoValueForm(forms.ModelForm):
         category = self.cleaned_data['category']
         parent_tag = category.parent_tag
         instance.parent_tag = parent_tag
-        problems = self.cleaned_data.get('problems').prefetch_related('origintag_set')
-        for problem in problems:
-            if parent_tag not in problem.origintag_set.all():
-                parent_tag.problems.add(problem)
+        if 'problems' in self.cleaned_data:
+            problems = self.cleaned_data.get('problems').prefetch_related('origintag_set')
+            for problem in problems:
+                if parent_tag not in problem.origintag_set.all():
+                    parent_tag.problems.add(problem)
 
         if commit:
             instance.save()


### PR DESCRIPTION
When the oioioi instance has a lot of problems, the views load a very long time (on szkopuł they take more than a minute and they timeout). I don't think many people use origin tags and probably even less use the problem field in the admin views, so I believe this is safe to hide.