### PR TITLE
Fix TeacherAuthBackend

### DIFF
--- a/oioioi/teachers/auth.py
+++ b/oioioi/teachers/auth.py
@@ -41,7 +41,7 @@ class TeacherAuthBackend(object):
                     user=user_obj, is_active=True
                 ).exists()
             return user_obj._is_teacher
-        if perm == 'contests.contest_admin' and isinstance(obj, Contest):
+        if (perm == 'contests.contest_admin' or perm == 'contests.contest_basicadmin') and isinstance(obj, Contest):
             if not hasattr(user_obj, '_teacher_perms_cache'):
                 user_obj._teacher_perms_cache = set(
                     ContestTeacher.objects.filter(


### PR DESCRIPTION
The PR that introduced Contest owner permission (#257) changed the `can_admin_contest` function to this:
https://github.com/sio2project/oioioi/blob/288ecffffd14d83020d9b3a7e541f356b2087a66/oioioi/contests/utils.py#L458-L460

Previously, the function also checked for the `contests.contest_admin` permission. The `TeacherAuthBackend` was invalid, because it only checked for `contests.contest_admin` permission and not for the `contests.contest_basicadmin` permission, which is a subset of `contest_admin` permission. This resulted in teachers not being able to see their contests