### PR TITLE
Another TeacherAuthBackend fix

### DIFF
--- a/oioioi/teachers/auth.py
+++ b/oioioi/teachers/auth.py
@@ -23,7 +23,7 @@ class TeacherAuthBackend(object):
             return Q_always_true()
         if perm == 'teachers.teacher':
             raise ValueError("teachers.teacher is not a per-object permission")
-        if perm == 'contests.contest_admin' and obj_class is Contest:
+        if (perm == 'contests.contest_admin' or perm == 'contests.contest_basicadmin') and obj_class is Contest:
             if Teacher.objects.filter(user=user, is_active=True).exists():
                 return Q(
                     contestteacher__teacher__user=user,


### PR DESCRIPTION
We missed one more place, which caused that teachers weren't able to see their contests in the contest list