### PR TITLE
Fix admin menu mixins

### DIFF
--- a/oioioi/questions/admin.py
+++ b/oioioi/questions/admin.py
@@ -147,7 +147,7 @@ class MessageNotifierContestAdminMixin(object):
 
     def __init__(self, *args, **kwargs):
         super(MessageNotifierContestAdminMixin, self).__init__(*args, **kwargs)
-        self.inlines = self.inlines + [MessageNotifierConfigInline]
+        self.inlines = tuple(self.inlines) + (MessageNotifierConfigInline,)
 
 
 ContestAdmin.mix_in(MessageNotifierContestAdminMixin)

--- a/oioioi/zeus/admin.py
+++ b/oioioi/zeus/admin.py
@@ -42,4 +42,4 @@ class ZeusProblemAdminMixin(object):
 
     def __init__(self, *args, **kwargs):
         super(ZeusProblemAdminMixin, self).__init__(*args, **kwargs)
-        self.inlines = [ZeusProblemDataInline] + self.inlines
+        self.inlines = tuple(self.inlines) + (ZeusProblemDataInline,)


### PR DESCRIPTION
Fixes an issue that caused a crash with certain enabled app combinations due to mismatch between types used for adding admin menu mixins.