### PR TITLE
Attachments in alphabetic order in groups

### DIFF
--- a/oioioi/contests/tests/tests.py
+++ b/oioioi/contests/tests/tests.py
@@ -1634,24 +1634,26 @@ class TestAttachments(TestCase, TestStreamingMixin):
         list_url = reverse('contest_files', kwargs={'contest_id': contest.id})
         self.assertTrue(self.client.login(username='test_admin'))
 
-        tp = TestsPackage.objects.create(
+        # Models have names that would make them sorted in a wrong order with old sorting.
+        TestsPackage.objects.create(
             problem=problem,
-            name='test-package',
+            name='A-test-package',
+
         )
-        pa = ProblemAttachment.objects.create(
+        ProblemAttachment.objects.create(
             problem=problem,
             description='problem-attachment',
-            content=ContentFile(b'content-of-pa', name='pa.txt'),
+            content=ContentFile(b'content-of-pa', name='B-pa.txt'),
         )
-        ca = ContestAttachment.objects.create(
+        ContestAttachment.objects.create(
             contest=contest,
             description='contest-attachment',
-            content=ContentFile(b'content-of-ca', name='ca.txt'),
+            content=ContentFile(b'content-of-ca', name='C-ca.txt'),
         )
 
         response = self.client.get(list_url)
-        self.assertContains(response, 'test-package')
-        tp_pos = response.content.find(b'test-package')
+        self.assertContains(response, 'A-test-package')
+        tp_pos = response.content.find(b'A-test-package')
         self.assertContains(response, 'problem-attachment')
         pa_pos = response.content.find(b'problem-attachment')
         self.assertContains(response, 'contest-attachment')

--- a/oioioi/contests/tests/tests.py
+++ b/oioioi/contests/tests/tests.py
@@ -75,9 +75,8 @@ from oioioi.simpleui.views import (
 from oioioi.teachers.views import (
     contest_dashboard_redirect as teachers_contest_dashboard,
 )
-from rest_framework.test import APITestCase
-
 from oioioi.testspackages.models import TestsPackage
+from rest_framework.test import APITestCase
 
 
 class TestModels(TestCase):

--- a/oioioi/contests/tests/tests.py
+++ b/oioioi/contests/tests/tests.py
@@ -1637,28 +1637,40 @@ class TestAttachments(TestCase, TestStreamingMixin):
         # Models have names that would make them sorted in a wrong order with old sorting.
         TestsPackage.objects.create(
             problem=problem,
-            name='A-test-package',
-
+            name='A-2-test-package',
+        )
+        TestsPackage.objects.create(
+            problem=problem,
+            name='A-1-test-package',
         )
         ProblemAttachment.objects.create(
             problem=problem,
             description='problem-attachment',
-            content=ContentFile(b'content-of-pa', name='B-pa.txt'),
+            content=ContentFile(b'content-of-pa', name='B-2-pa.txt'),
+        )
+        ProblemAttachment.objects.create(
+            problem=problem,
+            description='problem-attachment',
+            content=ContentFile(b'content-of-pa', name='B-1-pa.txt'),
         )
         ContestAttachment.objects.create(
             contest=contest,
             description='contest-attachment',
-            content=ContentFile(b'content-of-ca', name='C-ca.txt'),
+            content=ContentFile(b'content-of-ca', name='C-2-ca.txt'),
+        )
+        ContestAttachment.objects.create(
+            contest=contest,
+            description='contest-attachment',
+            content=ContentFile(b'content-of-ca', name='C-1-ca.txt'),
         )
 
         response = self.client.get(list_url)
-        self.assertContains(response, 'A-test-package')
-        tp_pos = response.content.find(b'A-test-package')
-        self.assertContains(response, 'problem-attachment')
-        pa_pos = response.content.find(b'problem-attachment')
-        self.assertContains(response, 'contest-attachment')
-        ca_pos = response.content.find(b'contest-attachment')
-        self.assertTrue(ca_pos < pa_pos < tp_pos)
+        last = 0
+        for name in ['C-1-ca.txt', 'C-2-ca.txt', 'B-1-pa.txt', 'B-2-pa.txt', 'A-1-test-package', 'A-2-test-package']:
+            self.assertContains(response, name)
+            pos = response.content.find(name.encode())
+            self.assertTrue(pos > last)
+            last = pos
 
 
 class TestRoundExtension(TestCase, SubmitFileMixin):

--- a/oioioi/contests/views.py
+++ b/oioioi/contests/views.py
@@ -539,6 +539,7 @@ def contest_files_view(request):
 
     round_file_exists = contest_files.filter(round__isnull=False).exists()
     add_category_field = round_file_exists or problem_files.exists()
+    all_rows = []
     rows = [
         {
             'category': cf.round if cf.round else '',
@@ -553,7 +554,10 @@ def contest_files_view(request):
         }
         for cf in contest_files
     ]
-    rows += [
+    rows.sort(key=itemgetter('name'))
+    all_rows += rows
+
+    rows = [
         {
             'category': pf.problem,
             'name': pf.download_name,
@@ -567,12 +571,15 @@ def contest_files_view(request):
         }
         for pf in problem_files
     ]
-    rows += additional_files
+    rows.sort(key=itemgetter('name'))
+    all_rows += rows
+    additional_files.sort(key=itemgetter('name'))
+    all_rows += additional_files
     return TemplateResponse(
         request,
         'contests/files.html',
         {
-            'files': rows,
+            'files': all_rows,
             'files_on_page': getattr(settings, 'FILES_ON_PAGE', 100),
             'add_category_field': add_category_field,
             'show_pub_dates': True,

--- a/oioioi/contests/views.py
+++ b/oioioi/contests/views.py
@@ -568,7 +568,6 @@ def contest_files_view(request):
         for pf in problem_files
     ]
     rows += additional_files
-    rows.sort(key=itemgetter('name'))
     return TemplateResponse(
         request,
         'contests/files.html',


### PR DESCRIPTION
I changed #388, so that attachments are sorted in alphabetic order in groups