### PR TITLE
Fix labels for checkboxes

### DIFF
--- a/oioioi/base/templates/ingredients/form-horizontal.html
+++ b/oioioi/base/templates/ingredients/form-horizontal.html
@@ -30,7 +30,7 @@
                 {% else %}
                     {{ field | add_class:"form-check-input" }}
                 {% endif %}
-                <label class="form-check-label">
+                <label class="form-check-label" for="id_{{ field.name }}">
                      {{ field.label }}
                 </label>
             </div>
@@ -83,4 +83,3 @@
         </script>
     {% endfor %}
 {% endif %}
-

--- a/oioioi/base/templates/ingredients/form.html
+++ b/oioioi/base/templates/ingredients/form.html
@@ -24,7 +24,7 @@
             {% else %}
                 {{ field | add_class:"form-check-input" }}
             {% endif %}
-            <label class="form-check-label">
+            <label class="form-check-label" for="id_{{ field.name }}">
                  {{ field.label }}
             </label>
         </div>
@@ -90,4 +90,3 @@
         </script>
     {% endfor %}
 {% endif %}
-


### PR DESCRIPTION
Labels for checkboxes where missing `for` attribute, which meant that clicking labels didn't toggle checkboxes