### PR TITLE
Fix cache related bug on Szkopul

### DIFF
--- a/oioioi/problems/utils.py
+++ b/oioioi/problems/utils.py
@@ -411,6 +411,7 @@ def filter_my_all_visible_submissions(request, queryset):
 
     result = Submission.objects.none()
     resolved = set()
+    prev_contest = request.contest
 
     for submission in queryset:
         pi = submission.problem_instance
@@ -434,5 +435,8 @@ def filter_my_all_visible_submissions(request, queryset):
             request, current_queryset
         )
         result = result.union(current_queryset)
+        if hasattr(request, '_cache'): # Delete cache so that e.g. `is_contest_basicadmin` doesn't return wrong results
+            delattr(request, '_cache')
+    request.contest = prev_contest
 
     return result


### PR DESCRIPTION
There was a bug on the Szkopul's main page where submission's score was shown when it shouldn't (for example when the round hasn't ended). This only happened when the user was a contest admin in another contest. The function `filter_my_all_visible_submissions` which is used on the Szkopul's main page changes `request.contest` and calls functions that call for example `is_contest_basicadmin`. Since `is_contest_basicadmin` caches its result, all other calls to this function returned True. So when the function `contests/controllers.py:results_visible`  (which uses `is_contest_basicadmin`) is called, it always returned True. 

https://github.com/sio2project/oioioi/blob/a5be176cf1b6ad79293963a1b185a8a906962941/oioioi/contests/controllers.py#L827-L841