### PR TITLE
Center contest logos (#408)

### DIFF
--- a/oioioi/contestlogo/templates/contestlogo/logo.html
+++ b/oioioi/contestlogo/templates/contestlogo/logo.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
-<div class="empty-space-filler-bottom">
+<div class="empty-space-filler-bottom text-center">
     <a href="{{ link }}">
-        <img alt='{% trans "Contest logo" %}' class="img-responsive center-block" src="{{ url }}">
+        <img alt='{% trans "Contest logo" %}' class="img-responsive" src="{{ url }}">
     </a>
 </div>


### PR DESCRIPTION
Fix for [#408](https://github.com/sio2project/oioioi/issues/408)

Centered contest images using text-align and also deleted unused class "center-block".