### PR TITLE
Fix and improve the docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN pip3 install --user bsddb3==6.2.7
 WORKDIR /sio2/oioioi
 
 COPY --chown=oioioi:oioioi setup.py requirements.txt ./
-RUN pip3 install -r requirements.txt --user
+RUN pip3 install -r requirements.txt --user filetracker[server]
 COPY --chown=oioioi:oioioi requirements_static.txt ./
 RUN pip3 install -r requirements_static.txt --user
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-# https://github.com/docker/cli/issues/1293
 services:
   db:
     image: library/postgres:12.2
@@ -27,6 +25,7 @@ services:
     # - "7887:7887"
     volumes:
       - .:/sio2/oioioi
+      - filetracker-data-dev:/sio2/deployment/media
 #      - ./deployment:/sio2/deployment
     stop_grace_period: 3m
     depends_on:
@@ -50,3 +49,4 @@ services:
     stop_grace_period: 1m
 volumes:
   postgress-data-dev:
+  filetracker-data-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: library/postgres:12.2
@@ -18,6 +17,8 @@ services:
     depends_on:
       - db
       - broker
+    volumes:
+      - filetracker-data:/sio2/deployment/media
   worker:
     image: sio2project/oioioi:$OIOIOI_VERSION
     command: ["/sio2/oioioi/worker_init.sh"]
@@ -34,3 +35,4 @@ services:
     stop_grace_period: 1m
 volumes:
   postgress-data:
+  filetracker-data:

--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -25,7 +25,8 @@ BASE_DOCKER_COMMAND = "OIOIOI_UID=$(id -u) docker compose" + \
 RAW_COMMANDS = [
     ("build", "Build OIOIOI container from source.", "build", True),
     ("up", "Run all SIO2 containers", "up -d"),
-    ("down", "Stop and remove all SIO2 containers", "down", True),
+    ("down", "Stop and remove all SIO2 containers", "down"),
+    ("wipe", "Stop all SIO2 containers and DESTROY all data", "down -v", True),
     ("run", "Run server", "{exec} web python3 manage.py runserver 0.0.0.0:8000"),
     ("stop", "Stop all SIO2 containers", "stop"),
     ("bash", "Open command prompt on web container.", "{exec} web bash"),


### PR DESCRIPTION
This PR fixes building the docker image, as after the recent change in filetracker packaging one must explicitly specify `[server]` to install dependencies for running an ft server. Without this, the filetracker server can't start when it is supposed to receive sandboxes.

I opted for putting this only in the Dockerfile, as manual setups may not need to run an ft server.

Additionally, I made the filetracker data live in a docker volume when running via `easy_toolbox`/`docker-compose`.
Without this, after one runs `./easy_toolbox.py down`, they get and inconsistent state: the db remains, but files on filetracker are gone.
I added the `wipe` command to `easy_toolbox` to allow for clearing the volumes and marked the `down` one as non-dangerous.

I also removed the `version` entries from docker-compose files due to this warning:
```
WARN[0000] .../oioioi/docker-compose-dev.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```
The issue mentioned in a related comment was resolved a few years ago.