### PR TITLE
Fix flaky test_single_file_replacement test #440

### DIFF
--- a/oioioi/sinolpack/tests.py
+++ b/oioioi/sinolpack/tests.py
@@ -109,7 +109,7 @@ class TestSinolPackage(TestCase, TestStreamingMixin):
         problem = Problem.objects.get()
         self.assertEqual(problem.name, 'Testowe')
 
-    @override_settings(CONTEST_MODE=ContestMode.neutral)
+    @override_settings(CONTEST_MODE=ContestMode.neutral, USE_SINOLPACK_MAKEFILES=False)
     def test_single_file_replacement(self):
         filename = get_test_filename('test_simple_package.zip')
         old_statement = 'tst/doc/tstzad.pdf'


### PR DESCRIPTION
This test failed every 10~30 runs because of LaTeX file compilation for the package running while the test is taking place.
Sometimes the compiled LaTeX PDF replaced the PDF we just changed, causing the assertion to fail.

Disabling USE_SINOLPACK_MAKEFILES for this test stops the LaTeX file from compiling and replacing the file we are comparing.

After this change I ran this test 200+ times and didn't fail, so I guess it is fixed.
