### PR TITLE
[Demo] Add a simple oauth implementation via django-oauth-toolkit

### DIFF
--- a/oioioi/default_settings.py
+++ b/oioioi/default_settings.py
@@ -286,6 +286,7 @@ INSTALLED_APPS = (
     'oioioi.quizzes',
     'oioioi._locale',
     'oioioi.interactive',
+    'oioioi.oauth',
 
     'djsupervisor',
     'registration',
@@ -313,6 +314,7 @@ INSTALLED_APPS = (
 
     'nested_admin',
     'coreapi',
+    'oauth2_provider',
     'rest_framework',
     'rest_framework.authtoken',
 
@@ -845,6 +847,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
     ),
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }

--- a/oioioi/oauth/urls.py
+++ b/oioioi/oauth/urls.py
@@ -1,0 +1,33 @@
+import oauth2_provider.views as oauth2_views
+from django.conf import settings
+from django.contrib import admin as django_admin
+from django.views import i18n
+from django.urls import include, re_path
+
+app_name = 'oauth'
+
+oauth2_endpoint_views = [
+    re_path(r'^authorize/', oauth2_views.AuthorizationView.as_view(), name="authorize"),
+    re_path(r'^token/', oauth2_views.TokenView.as_view(), name="token"),
+    re_path(r'^revoke-token/', oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+]
+
+if settings.DEBUG:
+    # OAuth2 Application Management endpoints
+    oauth2_endpoint_views += [
+        re_path(r'^applications/', oauth2_views.ApplicationList.as_view(), name="list"),
+        re_path(r'^applications/register/', oauth2_views.ApplicationRegistration.as_view(), name="register"),
+        re_path(r'^applications/<pk>/', oauth2_views.ApplicationDetail.as_view(), name="detail"),
+        re_path(r'^applications/<pk>/delete/', oauth2_views.ApplicationDelete.as_view(), name="delete"),
+        re_path(r'^applications/<pk>/update/', oauth2_views.ApplicationUpdate.as_view(), name="update"),
+    ]
+
+    oauth2_endpoint_views += [
+        re_path(r'^authorized-tokens/', oauth2_views.AuthorizedTokensListView.as_view(), name="authorized-token-list"),
+        re_path(r'^authorized-tokens/<pk>/delete/', oauth2_views.AuthorizedTokenDeleteView.as_view(),
+            name="authorized-token-delete"),
+    ]
+
+urlpatterns = [
+    re_path(r'^o/', include((oauth2_endpoint_views, 'oauth2_provider'), namespace="oauth2_provider")),
+]

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ requirements = [
     "django-debug-toolbar",
     "django-extensions>=3.2,<3.3",
     "djangorestframework>=3.14,<3.15",
+    "django-oauth-toolkit>=3.0,<3.1",
     "Werkzeug",
     "pytest>=7.2,<8.0",
     "pytest-cov>=4.0,<5.0",


### PR DESCRIPTION
Adding barebones oauth support is pretty trivial when using django-oauth-toolkit and this commit demonstrates the MVP. In a debug environment as per the [docs](https://django-oauth-toolkit.readthedocs.io/en/latest/rest-framework/getting_started.html#step-2-create-a-simple-api) one can use `/o/applications/` to register an oauth2 app with ex;
```
Client Type: confidential
Authorization Grant Type: Resource owner password-based
```
then retrieve an access token for admin (after replacing `<client_id>`, `<client_secret>` with the appropriate values) using `curl`;
```sh
curl -X POST -d "grant_type=password&username=admin&password=admin" -u"<client_id>:<client_secret>" http://localhost:8000/o/token/
```
and authenticate API calls via the access token (using the bearer scheme) which can be refreshed with the refresh token as in the spec. Other oauth2 flows work out of the box as well. In a production environment, I would implement special admin pages for managing the applications, and add config options for enabling oauth/defining clients. The toolkit package also adds some new migrations for the oauth-related models which have to be applied in current installations.

## The things to consider are;
- Using OIDC
- What should be included in a default installation
- What means of configuration would be preferred (defining clients statically in config files/managing them via a webui)

This pull request would be very useful for the upcoming TAG semester, in my opinion, as it greatly simplifies creating discrete applications that interconnect with oioioi installations. 