### PR TITLE
Fix `get_queryset()` on Problem admin

### DIFF
--- a/oioioi/problems/admin.py
+++ b/oioioi/problems/admin.py
@@ -480,8 +480,10 @@ class ProblemAdmin(admin.ModelAdmin):
             combined = queryset.none()
         else:
             combined = request.user.problem_set.all()
+        if request.user.is_superuser:
+            return queryset
         if request.user.has_perm('problems.problems_db_admin'):
-            combined |= queryset.filter(contest__isnull=True)
+            combined |= queryset.filter(visibility=Problem.VISIBILITY_PUBLIC)
         if is_contest_basicadmin(request):
             combined |= queryset.filter(contest=request.contest)
         return combined

--- a/oioioi/problems/tests/test_problem.py
+++ b/oioioi/problems/tests/test_problem.py
@@ -80,6 +80,12 @@ class TestProblemViews(TestCase, TestStreamingMixin):
         self.assertContains(response, 'Sum')
 
         self.assertTrue(self.client.login(username='test_user'))
+
+        # Users with problem.problems_db_admin can only see problems with visibility set to public.
+        problem = Problem.objects.get()
+        problem.visibility = Problem.VISIBILITY_PUBLIC
+        problem.save()
+
         check_not_accessible(self, url)
 
         user = User.objects.get(username='test_user')


### PR DESCRIPTION
Super user should have access to all problems and `problems.problems_db_admin` should have access to any public problems, not only problems without a contest.