### PR TITLE
Fix flaky test TestProblemsetFilters::test_filters. Closes #440

### DIFF
--- a/oioioi/problems/tests/test_problemset.py
+++ b/oioioi/problems/tests/test_problemset.py
@@ -219,7 +219,9 @@ class TestProblemsetFilters(TestCase):
             self.assertEqual(response.status_code, 200)
 
             for problem in self.problems:
+                problemTag = f"<td>{problem}</td>"
+
                 if problem in filtered:
-                    self.assertContains(response, problem)
+                    self.assertContains(response, problemTag, html=True)
                 else:
-                    self.assertNotContains(response, problem)
+                    self.assertNotContains(response, problemTag, html=True)


### PR DESCRIPTION
### The problem
This test used to check for the presence of a problem by asserting that the response HTML contained the problem name.
However, the response also included an HTML form with a generated CSRF token, sometimes this token would contain the problem name (test problems have short names like `aaa` so it wasn't that rare).
This caused the test to randomly fail.

### Solution
Now the test expliclitly searches for a HTML tag with the necessary problem name.