### PR TITLE
Mock csrf token in all tests. Fixes #454

### DIFF
--- a/oioioi/base/tests/__init__.py
+++ b/oioioi/base/tests/__init__.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 
 import pytest
 import urllib.parse
+from unittest import mock
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
@@ -42,6 +43,15 @@ class _AssertNumQueriesLessThanContext(CaptureQueriesContext):
 
 
 class TestCase(DjangoTestCase):
+
+    def setUp(self):
+        csrf_patch = mock.patch(
+            'django.middleware.csrf.get_token', 
+            mock.Mock(return_value='deterministicToken')
+        )
+
+        csrf_patch.start()
+        self.addCleanup(csrf_patch.stop)
 
     # Based on: https://github.com/revsys/django-test-plus/blob/master/test_plus/test.py#L236
     def assertNumQueriesLessThan(self, num, *args, **kwargs):


### PR DESCRIPTION
Instead of changing all test that use assertNotContains, we can just mock the csrf token for testing so it always has the same value. Thanks to this the generated HTML does not contain randomly generated strings, so tests should not fail randomly anymore. 