### PR TITLE
Action speedup

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,9 +28,8 @@ jobs:
           python easy_toolbox.py up --no-input
 
       - name: Wait for migrations
-        uses: whatnick/wait-action@master
-        with:
-          time: 30s
+        run: |
+          docker compose logs -f | grep -m 1 "Init Finished"
 
       - name: Apply CyPress settings
         run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -45,7 +45,7 @@ jobs:
           ./test_cypress.sh
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
             name: cypress-screenshots

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y curl libpq-dev libdb-dev
-        sudo apt-get install -y fp-compiler fp-units-base fp-units-math
         sudo apt-get install -y texlive-latex-base texlive-lang-polish texlive-lang-czechslovak texlive-latex-extra texlive-pstricks texlive-luatex
 
     - name: Install pip dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,4 +32,4 @@ jobs:
 
     - name: Run tests
       run: |
-        ./test.sh --cov-report term --cov-report xml:coverage.xml --cov=oioioi --migrations --runslow -v
+        ./test.sh -n auto --cov-report term --cov-report xml:coverage.xml --cov=oioioi --migrations --runslow -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y curl libpq-dev libdb-dev
-        sudo apt-get install -y fp-compiler fp-units-base fp-units-math
         sudo apt-get install -y texlive-latex-base texlive-lang-polish texlive-latex-extra texlive-pstricks texlive-luatex
 
     - name: Install pip dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,15 +26,6 @@ jobs:
         sudo apt-get install -y fp-compiler fp-units-base fp-units-math
         sudo apt-get install -y texlive-latex-base texlive-lang-polish texlive-latex-extra texlive-pstricks texlive-luatex
 
-    - name: Cache restore pip
-      id: cache-pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'requirements*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'requirements*.txt') }}
-
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,4 +43,4 @@ jobs:
 
     - name: Run tests
       run: |
-        ./test.sh --migrations
+        ./test.sh -n auto --migrations

--- a/.github/workflows/translations-download.yml
+++ b/.github/workflows/translations-download.yml
@@ -26,7 +26,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y curl libpq-dev libdb-dev gettext
-        sudo apt-get install -y fp-compiler fp-units-base fp-units-math
  
     - name: Install pip dependencies
       run: |

--- a/.github/workflows/translations-download.yml
+++ b/.github/workflows/translations-download.yml
@@ -27,16 +27,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y curl libpq-dev libdb-dev gettext
         sudo apt-get install -y fp-compiler fp-units-base fp-units-math
-
-    - name: Cache restore pip
-      id: cache-pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'requirements*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'requirements*.txt') }}
-
+ 
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -26,7 +26,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y curl libpq-dev libdb-dev gettext
-        sudo apt-get install -y fp-compiler fp-units-base fp-units-math
 
     - name: Install pip dependencies
       run: |

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -28,15 +28,6 @@ jobs:
         sudo apt-get install -y curl libpq-dev libdb-dev gettext
         sudo apt-get install -y fp-compiler fp-units-base fp-units-math
 
-    - name: Cache restore pip
-      id: cache-pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'requirements*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'requirements*.txt') }}
-
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools

--- a/oioioi/contests/tests/tests.py
+++ b/oioioi/contests/tests/tests.py
@@ -2173,11 +2173,13 @@ class TestPermissionsBasicAdmin(TestCase):
             'oioioi.programs.controllers.ProgrammingContestController'
         )
         self.contest.save()
+
+        unregister_contest_dashboard_view(simpleui_contest_dashboard)
+        unregister_contest_dashboard_view(teachers_contest_dashboard)
+
         super().setUp()
 
     def test_dashboard(self):
-        unregister_contest_dashboard_view(simpleui_contest_dashboard)
-        unregister_contest_dashboard_view(teachers_contest_dashboard)
         self.assertTrue(self.client.login(username='test_contest_basicadmin'))
         url = reverse('default_contest_view', kwargs={'contest_id': 'c'})
         response = self.client.get(url, follow=True)

--- a/oioioi_init.sh
+++ b/oioioi_init.sh
@@ -9,4 +9,6 @@ if [ "$1" == "--dev" ]; then
     ./manage.py loaddata ../oioioi/extra/dbdata/default_admin.json
 fi
 
+echo "Init Finished"
+
 exec ./manage.py supervisor --logfile=/sio2/deployment/logs/supervisor.log


### PR DESCRIPTION
Managed to speedup test actions by running django tests in parallel. Also made the cypress task actually work again.

Trying to cache pip packages didn't improve performance (when cache was used it saved ~5s of runtime, but saving the cache took ~2 minutes every time it needed to be regenerated). Trying to use containers with preinstalled apt dependencies improved performance only slightly, but introduced multiple other issues.