### PR TITLE
Add a note about copying limits

### DIFF
--- a/oioioi/problems/forms.py
+++ b/oioioi/problems/forms.py
@@ -105,7 +105,7 @@ class ProblemSiteForm(forms.ModelForm):
 
 class ProblemsetSourceForm(forms.Form):
     url_key = forms.CharField(label=_("Enter problem's secret key"),
-                              help_text=("Please note that the time and memory limits will be copied\
+                              help_text=_("Please note that the time and memory limits will be copied\
                                           from the source problem. If they have been overriden\
                                           in a specific contest, these settings will not be copied.\
                                           If you want to copy the limits from a specific contest,\

--- a/oioioi/problems/forms.py
+++ b/oioioi/problems/forms.py
@@ -104,7 +104,14 @@ class ProblemSiteForm(forms.ModelForm):
 
 
 class ProblemsetSourceForm(forms.Form):
-    url_key = forms.CharField(label=_("Enter problem's secret key"), required=True)
+    url_key = forms.CharField(label=_("Enter problem's secret key"),
+                              help_text=("Please note that the time and memory limits will be copied\
+                                          from the source problem. If they have been overriden\
+                                          in a specific contest, these settings will not be copied.\
+                                          If you want to copy the limits from a specific contest,\
+                                          please go the contest's problem list and use the 'Attach\
+                                          to another contest' option."),
+                              required=True)
 
     def __init__(self, url_key, *args, **kwargs):
         super(ProblemsetSourceForm, self).__init__(*args, **kwargs)

--- a/oioioi/problems/templates/problems/problemset-source.html
+++ b/oioioi/problems/templates/problems/problemset-source.html
@@ -20,7 +20,7 @@
         <span class="help-inline">{{ error }}</span>
         {% endfor %}
         {% if form.url_key.help_text %}
-        <p class="help-block">{{ form.url_key.help_text }}</p>
+        <small class="help text-muted form-text">{{ form.url_key.help_text }}</small>
         {% endif %}
     </div>
 


### PR DESCRIPTION
Copying problems from url keys does not copy contest-specific time or memory limits. Instead, the limits are set to the default package settings. In order to copy time limits with contest-specific settings, one has to go to a contest's problem list and choose the 'Attach to another contest' option.

This pull request adds a note about it displayed when adding problems through url keys.

It is a solution to the issue[ #471](https://github.com/sio2project/oioioi/issues/471).