### PR TITLE
Fix Docker Compose files and build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build and publish Docker image
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -49,7 +49,9 @@ services:
   worker:
     image: sio2project/oioioi-dev
     command: ["/sio2/oioioi/worker_init.sh"]
-    environment: *common-envs
+    environment:
+      WEB_URL: "web:8000"
+      <<: *common-envs
     volumes:
       - .:/sio2/oioioi
     stop_grace_period: 1m

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,3 +1,8 @@
+x-common-envs: &common-envs
+ FILETRACKER_URL: 'http://web:9999'
+ DATABASE_HOST: 'db'
+ DATABASE_PORT: '5432'
+
 services:
   db:
     image: library/postgres:12.2
@@ -27,9 +32,7 @@ services:
       RABBITMQ_PASSWORD: 'oioioi'
       FILETRACKER_LISTEN_ADDR: '0.0.0.0'
       FILETRACKER_LISTEN_PORT: '9999'
-      FILETRACKER_URL: 'http://web:9999'
-      DATABASE_HOST: 'db'
-      DATABASE_PORT: '5432'
+      <<: *common-envs
     ports:
     # web server
       - "8000:8000"
@@ -46,6 +49,7 @@ services:
   worker:
     image: sio2project/oioioi-dev
     command: ["/sio2/oioioi/worker_init.sh"]
+    environment: *common-envs
     volumes:
       - .:/sio2/oioioi
     stop_grace_period: 1m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,9 @@ services:
   worker:
     image: sio2project/oioioi:$OIOIOI_VERSION
     command: ["/sio2/oioioi/worker_init.sh"]
-    environment: *common-envs
+    environment:
+      WEB_URL: "web:8000"
+      <<: *common-envs
     stop_grace_period: 1m
     cap_add:
       - ALL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,8 @@
+x-common-envs: &common-envs
+ FILETRACKER_URL: 'http://web:9999'
+ DATABASE_HOST: 'db'
+ DATABASE_PORT: '5432'
+
 services:
   db:
     image: library/postgres:12.2
@@ -19,9 +24,7 @@ services:
       RABBITMQ_PASSWORD: 'oioioi'
       FILETRACKER_LISTEN_ADDR: '0.0.0.0'
       FILETRACKER_LISTEN_PORT: '9999'
-      FILETRACKER_URL: 'http://web:9999'
-      DATABASE_HOST: 'db'
-      DATABASE_PORT: '5432'
+      <<: *common-envs
     ports:
       - "8000:8000"
     stop_grace_period: 3m
@@ -33,6 +36,7 @@ services:
   worker:
     image: sio2project/oioioi:$OIOIOI_VERSION
     command: ["/sio2/oioioi/worker_init.sh"]
+    environment: *common-envs
     stop_grace_period: 1m
     cap_add:
       - ALL

--- a/worker_init.sh
+++ b/worker_init.sh
@@ -5,7 +5,7 @@ set -x
 sudo apt install -y proot
 
 /sio2/oioioi/wait-for-it.sh -t 60 "${DATABASE_HOST}:${DATABASE_PORT}"
-/sio2/oioioi/wait-for-it.sh -t 0  "web:8000"
+/sio2/oioioi/wait-for-it.sh -t 0  "${WEB_URL}"
 
 mkdir -pv /sio2/deployment/logs/database
 


### PR DESCRIPTION
Cypress tests failed due to missing env variables in the `worker` service in the Docker Compose files. To fix this, I added [common variables](https://github.com/compose-spec/compose-spec/blob/main/spec.md#extension) to these files. Additionally, I renamed `main` to `master` in the build action and added the `WEB_URL` env variable instead of hardcoding it in `worker_init.sh`.