### PR TITLE
Optimize Problem.name to support prefetching

### DIFF
--- a/oioioi/problems/models.py
+++ b/oioioi/problems/models.py
@@ -119,9 +119,13 @@ class Problem(models.Model):
 
     @cached_property
     def name(self):
-        problem_name = ProblemName.objects.filter(
-            problem=self, language=get_language()
-        ).first()
+        # We fetch all of self.names and filter by language in Python instead of Django. 
+        # This allows us to do prefetch_related('names'), which considerably speeds up 
+        # views such as task_archive_tag_view that query many problems and their associated names
+        problem_name = None
+        for name in self.names.all():
+            if name.language == get_language():
+                problem_name = name
         return problem_name.name if problem_name else self.legacy_name
 
     @property

--- a/oioioi/problems/models.py
+++ b/oioioi/problems/models.py
@@ -122,12 +122,12 @@ class Problem(models.Model):
         # We fetch all of self.names and filter by language in Python instead of Django. 
         # This allows us to do prefetch_related('names'), which considerably speeds up 
         # views such as task_archive_tag_view that query many problems and their associated names
-        try:
+
+        # Check if primary key exists, as it's needed to access related fields such as `names`
+        if self.pk:
             for problem_name in self.names.all():
                 if problem_name.language == get_language():
                     return problem_name.name
-        except:
-            pass
 
         return self.legacy_name
 

--- a/oioioi/problems/models.py
+++ b/oioioi/problems/models.py
@@ -122,11 +122,14 @@ class Problem(models.Model):
         # We fetch all of self.names and filter by language in Python instead of Django. 
         # This allows us to do prefetch_related('names'), which considerably speeds up 
         # views such as task_archive_tag_view that query many problems and their associated names
-        problem_name = None
-        for name in self.names.all():
-            if name.language == get_language():
-                problem_name = name
-        return problem_name.name if problem_name else self.legacy_name
+        try:
+            for problem_name in self.names.all():
+                if problem_name.language == get_language():
+                    return problem_name.name
+        except:
+            pass
+
+        return self.legacy_name
 
     @property
     def controller(self):

--- a/oioioi/problems/tests/test_problem.py
+++ b/oioioi/problems/tests/test_problem.py
@@ -4,6 +4,7 @@ import io
 
 import six
 import urllib.parse
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
@@ -21,6 +22,7 @@ from oioioi.problems.models import (
     DifficultyTag,
     DifficultyTagThrough,
     Problem,
+    ProblemName,
     ProblemAttachment,
     ProblemPackage,
     ProblemStatement,
@@ -867,3 +869,18 @@ class TestProblemSearch(TestCase, AssertContainsOnlyMixin):
         )
         self.assertEqual(response.status_code, 200)
         self.assert_contains_only(response, ())
+
+def problem_name(problem, language):
+    problem_name = ProblemName.objects.filter(
+        problem=problem, language=language
+    ).first()
+    return problem_name.name if problem_name else problem.legacy_name
+
+class TestProblemName(TestCase):
+    fixtures = ['test_problem_search']
+
+    def test_problem_names(self):
+        for (lang_code, _) in settings.LANGUAGES:
+            with override_settings(LANGUAGE_CODE=lang_code):
+                for problem in Problem.objects.all():
+                    self.assertEqual(problem.name, problem_name(problem, lang_code))

--- a/oioioi/problems/views.py
+++ b/oioioi/problems/views.py
@@ -895,7 +895,9 @@ def task_archive_tag_view(request, origin_tag):
         origin_tag.problems.all()
         .select_related('problemsite', 'main_problem_instance')
         .prefetch_related(
-            'origininfovalue_set__localizations', 'origininfovalue_set__category'
+            'origininfovalue_set__localizations', 
+            'origininfovalue_set__category',
+            'names'
         )
     )
     problems = _filter_problems_prefetched(problems, request.GET)


### PR DESCRIPTION
I changed the implementation of the name property of the Problem model. Now instead of querying the ProblemName table it goes through the names property, which can now be prefetched. This is what I do in task_archive_tag_view which dramatically speeds it up on large competitions, reducing the number of queries from linear in the number of problems to constant.

I also add a test to check that the implementations are consistent.