### PR TITLE
Mass create tool

### DIFF
--- a/oioioi/problems/management/commands/mass_create_tool.py
+++ b/oioioi/problems/management/commands/mass_create_tool.py
@@ -1,0 +1,481 @@
+import random
+import string
+import sys
+
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from oioioi.problems.models import (
+    Problem,
+    AlgorithmTag,
+    DifficultyTag,
+    AlgorithmTagThrough,
+    DifficultyTagThrough,
+    AlgorithmTagProposal,
+    DifficultyTagProposal,
+    ProblemSite,
+)
+
+User = get_user_model()
+
+def unsigned_int(value):
+    ivalue = int(value)
+    if ivalue < 0:
+        raise ValueError(f"{value} is not a non-negative integer")
+    return ivalue
+
+def get_unique_candidate(candidate_fn, uniqueness_fn, max_attempts=10):
+    """
+    Repeatedly calls candidate_fn() until uniqueness_fn(candidate) is True,
+    or max_attempts is reached. Raises CommandError if no unique candidate is found.
+    """
+    for attempt in range(max_attempts):
+        candidate = candidate_fn()
+        if uniqueness_fn(candidate):
+            return candidate
+    raise CommandError(
+        f"Failed to generate a unique candidate after {max_attempts} attempts"
+    )
+
+class Command(BaseCommand):
+    help = (
+        "!!! THIS TOOL IS INTENDED FOR BENCHMARKING AND TESTING PURPOSES ONLY -- DO NOT USE IN PRODUCTION !!! "
+        "Allows the creation of mock data for testing purposes. "
+        "Creates Problems, Users, Algorithm Tags, Difficulty Tags, Algorithm Tag Proposals, and "
+        "Algorithm Tag Through and Difficulty Tag Through records to assign tags to problems. Use with caution in production environments. "
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--wipe', '-w',
+            action='store_true',
+            help='Remove all previously generated mock data before creating new data'
+        )
+        parser.add_argument(
+            '--problems', '-p',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of problems to create (default: 0)'
+        )
+        parser.add_argument(
+            '--users', '-u',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of users to create (default: 0)'
+        )
+        parser.add_argument(
+            '--algotags', '-at',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of algorithm tags to create (default: 0)'
+        )
+        parser.add_argument(
+            '--difftags', '-dt',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of difficulty tags to create (default: 0)'
+        )
+        parser.add_argument(
+            '--algothrough', '-att',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of algorithm tag through records (assigning algorithm tags to problems) to create (default: 0)'
+        )
+        parser.add_argument(
+            '--diffthrough', '-dtt',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of difficulty tag through records (assigning difficulty tags to problems) to create (default: 0)'
+        )
+        parser.add_argument(
+            '--algoproposals', '-ap',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of algorithm tag proposals to create (default: 0)'
+        )
+        parser.add_argument(
+            '--diffproposals', '-dp',
+            type=unsigned_int,
+            default=0,
+            metavar='N',
+            help='Number of difficulty tag proposals to create (default: 0)'
+        )
+        parser.add_argument(
+            '--seed', '-s',
+            type=unsigned_int,
+            default=None,
+            metavar='SEED',
+            help='Random seed for reproducibility'
+        )
+
+    def create_unique_objects(self, count, candidate_prefix, random_length, uniqueness_fn, create_instance_fn, verbose_name, verbosity):
+        """
+        Creates a list of objects using get_unique_candidate.
+        - count: number of objects to create.
+        - candidate_prefix: A prefix string (e.g. 'prob_').
+        - random_length: Number of random characters to append.
+        - uniqueness_fn: Function taking candidate -> bool (should return True if candidate is unique).
+        - create_instance_fn: Function taking candidate -> instance (which should be saved later).
+        - verbose_name: A description used in output.
+        - verbosity: The current verbosity level.
+        Returns a list of created objects.
+        """
+        candidate_prefix = self.auto_prefix + candidate_prefix
+
+        objs = []
+        for i in range(count):
+            candidate_fn = lambda: candidate_prefix + ''.join(random.choices(string.ascii_lowercase, k=random_length))
+            try:
+                unique_candidate = get_unique_candidate(candidate_fn, uniqueness_fn)
+            except CommandError as e:
+                self.errors_found = True
+                self.stderr.write(self.style.ERROR(
+                    f"Failed to create {verbose_name} candidate: {e}. Stopping further creation for {verbose_name}."
+                ))
+                break
+            instance = create_instance_fn(unique_candidate)
+            instance.save()
+            objs.append(instance)
+            if verbosity >= 3:
+                self.stdout.write(self.style.SUCCESS(
+                    f"Created {verbose_name}: {unique_candidate} (ID: {getattr(instance, 'id', 'N/A')})"
+                ))
+            elif verbosity == 2:
+                sys.stdout.write(f"Created {i+1} of {count} {verbose_name}s\r")
+                sys.stdout.flush()
+        if verbosity == 2 and objs:
+            sys.stdout.write("\n")
+        return objs
+
+    def create_problems(self, count, verbosity):
+        """
+        Creates a list of Problems using create_unique_objects,
+        then creates associated ProblemSite objects.
+        - count: number of objects to create.
+        - candidate_prefix: A prefix string (e.g. 'prob_').
+        - random_length: Number of random characters to append.
+        - verbose_name: A description used in output.
+        - verbosity: The current verbosity level.
+        Returns a list of created objects.
+        """
+        created_problems = self.create_unique_objects(
+            count=count,
+            candidate_prefix='prob_',
+            random_length=10,
+            uniqueness_fn=lambda s: not Problem.objects.filter(short_name=s).exists(),
+            create_instance_fn=lambda candidate: Problem.create(short_name=candidate),
+            verbose_name="Problem",
+            verbosity=verbosity,
+        )
+        for problem in created_problems:
+            site = ProblemSite.objects.create(
+                problem=problem,
+                url_key=f"{problem.short_name}_site",
+            )
+            site.save()
+        return created_problems
+
+    def create_through_records(self, count, problems, tags, through_model, verbose_name, verbosity):
+        """
+        Creates a specified number of through-records connecting a problem and a tag.
+        For DifficultyTagThrough ensures that each problem is assigned to at most one difficulty tag.
+        For AlgorithmTagThrough ensures that each (problem, tag) pair is unique.
+        - count: number of through records to create.
+        - problems: list of existing problems.
+        - tags: list of existing tags.
+        - through_model: the through model class to use.
+        - verbose_name: description used in output.
+        - verbosity: the current verbosity level.
+        Returns a list of created through-records.
+        """
+        objs = []
+        for i in range(count):
+            candidate_fn = lambda: (random.choice(problems), random.choice(tags))
+            if through_model == DifficultyTagThrough:
+                uniqueness_fn = lambda candidate: not (
+                    through_model.objects.filter(problem=candidate[0]).exists() or
+                    any(r.problem == candidate[0] for r in objs)
+                )
+            else:
+                uniqueness_fn = lambda candidate: not (
+                    through_model.objects.filter(problem=candidate[0], tag=candidate[1]).exists() or
+                    any(r.problem == candidate[0] and r.tag == candidate[1] for r in objs)
+                )
+            try:
+                candidate = get_unique_candidate(candidate_fn, uniqueness_fn)
+            except CommandError as e:
+                self.errors_found = True
+                self.stderr.write(self.style.ERROR(
+                    f"Failed to create {verbose_name} candidate: {e}. Stopping further creation for {verbose_name}."
+                ))
+                break
+            record = through_model(problem=candidate[0], tag=candidate[1])
+            record.save()
+            objs.append(record)
+            if verbosity >= 3:
+                self.stdout.write(self.style.SUCCESS(
+                    f"Created {verbose_name}: Problem ID {candidate[0].id} - Tag {candidate[1].name}"
+                ))
+            elif verbosity == 2:
+                sys.stdout.write(f"Created {i+1} of {count} {verbose_name}s\r")
+                sys.stdout.flush()
+        if verbosity == 2 and count:
+            sys.stdout.write("\n")
+        return objs
+
+    def create_proposals(self, count, problems, users, tags, proposal_model, verbose_name, verbosity):
+        """
+        Creates algorithm tag proposals by pairing problems, users, and algotags randomly.
+        Returns a list of created AlgorithmTagProposal objects.
+        """
+        objs = []
+        for i in range(count):
+            problem = random.choice(problems)
+            user = random.choice(users)
+            tag = random.choice(tags)
+            proposal = proposal_model(problem=problem, user=user, tag=tag)
+            proposal.save()
+            objs.append(proposal)
+            if verbosity >= 3:
+                self.stdout.write(self.style.SUCCESS(
+                    f"Created Proposal: Problem ID {problem.id} - User {user.username} - Tag {tag.name}"
+                ))
+            elif verbosity == 2:
+                sys.stdout.write(f"Created {i+1} of {count} {verbose_name}s\r")
+                sys.stdout.flush()
+        if verbosity == 2 and objs:
+            sys.stdout.write("\n")
+        return objs
+
+    def write_summary(self, created, expected, object_name):
+        if expected == 0:
+            return
+        if created == expected:
+            msg = f"Created {expected} {object_name}."
+            self.stdout.write(self.style.SUCCESS(msg))
+        else:
+            msg = f"Created {created} of {expected} {object_name}."
+            self.stdout.write(self.style.WARNING(msg))
+
+    def remove_all_generated_data(self):
+        """
+        Removes all mass-generated mock data created using this tool.
+        """
+
+        # Delete Problems
+        prob_qs = Problem.objects.filter(short_name__startswith=self.auto_prefix)
+        prob_count = prob_qs.count()
+        prob_qs.delete()
+        self.stdout.write(self.style.SUCCESS(f"Deleted {prob_count} Problems"))
+
+        # Delete Users
+        user_qs = User.objects.filter(username__startswith=self.auto_prefix)
+        user_count = user_qs.count()
+        user_qs.delete()
+        self.stdout.write(self.style.SUCCESS(f"Deleted {user_count} Users"))
+
+        # Delete Algorithm Tags
+        algo_tag_qs = AlgorithmTag.objects.filter(name__startswith=self.auto_prefix)
+        algo_tag_count = algo_tag_qs.count()
+        algo_tag_qs.delete()
+        self.stdout.write(self.style.SUCCESS(f"Deleted {algo_tag_count} Algorithm Tags"))
+
+        # Delete Difficulty Tags
+        diff_tag_qs = DifficultyTag.objects.filter(name__startswith=self.auto_prefix)
+        diff_tag_count = diff_tag_qs.count()
+        diff_tag_qs.delete()
+        self.stdout.write(self.style.SUCCESS(f"Deleted {diff_tag_count} Difficulty Tags"))
+
+        self.stdout.write(self.style.SUCCESS("Through, Proposal and AggregatedProposal records are deleted on cascade, along with ProblemSites."))
+        self.stdout.write(self.style.SUCCESS("Mock data removal complete"))
+
+    def handle(self, *args, **options):
+        self.errors_found = False
+        self.auto_prefix = "_auto_"
+
+        wipe = options['wipe']
+        num_problems = options['problems']
+        num_users = options['users']
+        num_algotags = options['algotags']
+        num_difftags = options['difftags']
+        num_algothrough = options['algothrough']
+        num_diffthrough = options['diffthrough']
+        num_algoproposals = options['algoproposals']
+        num_diffproposals = options['diffproposals']
+        seed = options['seed']
+        verbosity = int(options.get('verbosity', 1))
+
+        total_objects_to_create = (
+            num_problems + num_users + num_algotags +
+            num_difftags + num_algothrough + num_diffthrough +
+            num_algoproposals + num_diffproposals
+        )
+
+        if not settings.DEBUG:
+            self.errors_found = True
+            self.stderr.write(self.style.ERROR(
+                "This command should only be run in DEBUG mode. "
+                "Please set DEBUG=True in your settings."
+            ))
+            return
+
+        if num_algothrough > 0 and (num_problems <= 0 or num_algotags <= 0):
+            self.errors_found = True
+            raise CommandError("Assigning algorithm tags to problems requires at least one problem and one algorithm tag to be created first.")
+
+        if num_diffthrough > 0 and (num_problems <= 0 or num_difftags <= 0):
+            self.errors_found = True
+            raise CommandError("Assigning difficulty tags to problems requires at least one problem and one difficulty tag to be created first.")
+
+        if num_algoproposals > 0 and (num_problems <= 0 or num_users <= 0 or num_algotags <= 0):
+            self.errors_found = True
+            raise CommandError("Creation of algorithm tag proposals requires at least one problem, one user, and one algorithm tag to be created first.")
+
+        if num_diffproposals > 0 and (num_problems <= 0 or num_users <= 0 or num_difftags <= 0):
+            self.errors_found = True
+            raise CommandError("Creation of difficulty tag proposals requires at least one problem, one user, and one difficulty tag to be created first.")
+
+        if wipe:
+            self.stdout.write(self.style.WARNING(
+                "Wiping all previously generated mock data."
+            ))
+            self.remove_all_generated_data()
+
+            if total_objects_to_create == 0:
+                return
+            else:
+                self.stdout.write(self.style.SUCCESS(
+                    "Wipe complete. Proceeding to create new mock data."
+                ))
+
+        if total_objects_to_create == 0:
+            self.stdout.write(self.style.WARNING(
+                "No objects specified for creation. Please set one or more counts to non-zero. "
+                "See --help for usage details."
+            ))
+            return
+
+        if seed is not None:
+            random.seed(seed)
+
+        created_problems = self.create_problems(
+            count=num_problems,
+            verbosity=verbosity,
+        )
+
+        created_users = self.create_unique_objects(
+            count=num_users,
+            candidate_prefix='user_',
+            random_length=10,
+            uniqueness_fn=lambda s: not User.objects.filter(username=s).exists(),
+            create_instance_fn=lambda candidate: User.objects.create_user(username=candidate, email=f"{candidate}@example.com", password="password"),
+            verbose_name="User",
+            verbosity=verbosity,
+        )
+
+        created_algotags = self.create_unique_objects(
+            count=num_algotags,
+            candidate_prefix='algo_',
+            random_length=8,
+            uniqueness_fn=lambda s: not AlgorithmTag.objects.filter(name=s).exists(),
+            create_instance_fn=lambda candidate: AlgorithmTag(name=candidate),
+            verbose_name="Algorithm Tag",
+            verbosity=verbosity,
+        )
+
+        created_difftags = self.create_unique_objects(
+            count=num_difftags,
+            candidate_prefix='diff_',
+            random_length=8,
+            uniqueness_fn=lambda s: not DifficultyTag.objects.filter(name=s).exists(),
+            create_instance_fn=lambda candidate: DifficultyTag(name=candidate),
+            verbose_name="Difficulty Tag",
+            verbosity=verbosity,
+        )
+
+        created_algothrough = []
+        if created_problems and created_algotags and num_algothrough > 0:
+            created_algothrough = self.create_through_records(
+                count=num_algothrough,
+                problems=created_problems,
+                tags=created_algotags,
+                through_model=AlgorithmTagThrough,
+                verbose_name="Algorithm Tag Through",
+                verbosity=verbosity,
+            )
+        elif num_algothrough > 0:
+            self.errors_found = True
+            self.stderr.write(self.style.ERROR(
+                "Not all prerequisites were created: skipping Algorithm Tag Through records."
+            ))
+
+        created_diffthrough = []
+        if created_problems and created_difftags and num_diffthrough > 0:
+            created_diffthrough = self.create_through_records(
+                count=num_diffthrough,
+                problems=created_problems,
+                tags=created_difftags,
+                through_model=DifficultyTagThrough,
+                verbose_name="Difficulty Tag Through",
+                verbosity=verbosity,
+            )
+        elif num_diffthrough > 0:
+            self.errors_found = True
+            self.stderr.write(self.style.ERROR(
+                "Not all prerequisites were created: skipping Difficulty Tag Through records."
+            ))
+
+        created_algoproposals = []
+        if created_problems and created_users and created_algotags:
+            created_algoproposals = self.create_proposals(
+                count=num_algoproposals,
+                problems=created_problems,
+                users=created_users,
+                tags=created_algotags,
+                proposal_model=AlgorithmTagProposal,
+                verbose_name="Algorithm Tag Proposal",
+                verbosity=verbosity,
+            )
+        elif num_algoproposals > 0:
+            self.errors_found = True
+            self.stderr.write(self.style.ERROR(
+                "Not all prerequisites were created: skipping Algorithm Tag Proposals."
+            ))
+
+        created_diffproposals = []
+        if created_problems and created_users and created_difftags:
+            created_diffproposals = self.create_proposals(
+                count=num_diffproposals,
+                problems=created_problems,
+                users=created_users,
+                tags=created_difftags,
+                proposal_model=DifficultyTagProposal,
+                verbose_name="Difficulty Tag Proposal",
+                verbosity=verbosity,
+            )
+        elif num_diffproposals > 0:
+            self.errors_found = True
+            self.stderr.write(self.style.ERROR(
+                "Not all prerequisites were created: skipping Difficulty Tag Proposals."
+            ))
+
+        overall_msg = "Mock data creation complete." if not self.errors_found else "Errors occurred during mock data creation."
+        overall_status = self.style.SUCCESS if not self.errors_found else self.style.WARNING
+        self.stdout.write(overall_status(overall_msg))
+
+        if verbosity >= 1:
+            self.write_summary(len(created_problems), options['problems'], "Problems")
+            self.write_summary(len(created_users), options['users'], "Users")
+            self.write_summary(len(created_algotags), options['algotags'], "Algorithm Tags")
+            self.write_summary(len(created_difftags), options['difftags'], "Difficulty Tags")
+            self.write_summary(len(created_algothrough), options['algothrough'], "Algorithm Tag Through Records")
+            self.write_summary(len(created_diffthrough), options['diffthrough'], "Difficulty Tag Through Records")
+            self.write_summary(len(created_algoproposals), options['algoproposals'], "Algorithm Tag Proposals")
+            self.write_summary(len(created_diffproposals), options['diffproposals'], "Difficulty Tag Proposals")

--- a/oioioi/problems/management/commands/mass_create_tool.py
+++ b/oioioi/problems/management/commands/mass_create_tool.py
@@ -356,18 +356,20 @@ class Command(BaseCommand):
             num_difftags + num_algothrough + num_diffthrough +
             num_algoproposals + num_diffproposals
         )
+        max_algothrough = num_problems * num_algotags
+        max_diffthrough = num_problems
 
         if not settings.DEBUG:
             self.errors_found = True
             raise CommandError("This command should only be run in DEBUG mode. Please set DEBUG=True in your settings.")
 
-        if num_algothrough > 0 and (num_problems <= 0 or num_algotags <= 0):
+        if num_algothrough > max_algothrough:
             self.errors_found = True
-            raise CommandError("Assigning algorithm tags to problems requires at least one problem and one algorithm tag to be created first.")
+            raise CommandError(f"For {num_problems} problems and {num_algotags} algorithm tags can create at most {max_algothrough} algorithm tag through records.")
 
-        if num_diffthrough > 0 and (num_problems <= 0 or num_difftags <= 0):
+        if num_diffthrough > max_diffthrough:
             self.errors_found = True
-            raise CommandError("Assigning difficulty tags to problems requires at least one problem and one difficulty tag to be created first.")
+            raise CommandError(f"For {num_problems} problems can create at most {max_diffthrough} difficulty tag through records.")
 
         if num_algoproposals > 0 and (num_problems <= 0 or num_users <= 0 or num_algotags <= 0):
             self.errors_found = True

--- a/oioioi/problems/management/commands/mass_create_tool.py
+++ b/oioioi/problems/management/commands/mass_create_tool.py
@@ -312,25 +312,21 @@ class Command(BaseCommand):
         Removes all mass-generated mock data created using this tool.
         """
 
-        # Delete Problems
         prob_qs = Problem.objects.filter(short_name__startswith=self.auto_prefix)
         prob_count = prob_qs.count()
         prob_qs.delete()
         self.stdout.write(self.style.SUCCESS(f"Deleted {prob_count} Problems"))
 
-        # Delete Users
         user_qs = User.objects.filter(username__startswith=self.auto_prefix)
         user_count = user_qs.count()
         user_qs.delete()
         self.stdout.write(self.style.SUCCESS(f"Deleted {user_count} Users"))
 
-        # Delete Algorithm Tags
         algo_tag_qs = AlgorithmTag.objects.filter(name__startswith=self.auto_prefix)
         algo_tag_count = algo_tag_qs.count()
         algo_tag_qs.delete()
         self.stdout.write(self.style.SUCCESS(f"Deleted {algo_tag_count} Algorithm Tags"))
 
-        # Delete Difficulty Tags
         diff_tag_qs = DifficultyTag.objects.filter(name__startswith=self.auto_prefix)
         diff_tag_count = diff_tag_qs.count()
         diff_tag_qs.delete()

--- a/oioioi/problems/management/commands/mass_create_tool.py
+++ b/oioioi/problems/management/commands/mass_create_tool.py
@@ -320,11 +320,7 @@ class Command(BaseCommand):
 
         if not settings.DEBUG:
             self.errors_found = True
-            self.stderr.write(self.style.ERROR(
-                "This command should only be run in DEBUG mode. "
-                "Please set DEBUG=True in your settings."
-            ))
-            return
+            raise CommandError("This command should only be run in DEBUG mode. Please set DEBUG=True in your settings.")
 
         if num_algothrough > 0 and (num_problems <= 0 or num_algotags <= 0):
             self.errors_found = True

--- a/oioioi/problems/models.py
+++ b/oioioi/problems/models.py
@@ -169,9 +169,9 @@ class Problem(models.Model):
         )
 
     def __str__(self):
-        return u'%(name)s (%(short_name)s)' % {
-            u'short_name': self.short_name,
-            u'name': self.name,
+        return '%(name)s (%(short_name)s)' % {
+            'short_name': self.short_name,
+            'name': self.name,
         }
 
     def save(self, *args, **kwargs):
@@ -254,7 +254,7 @@ class ProblemStatement(models.Model):
         verbose_name_plural = _("problem statements")
 
     def __str__(self):
-        return u'%s / %s' % (self.problem.name, self.filename)
+        return '%s / %s' % (self.problem.name, self.filename)
 
 
 
@@ -285,7 +285,7 @@ class ProblemAttachment(models.Model):
         verbose_name_plural = _("attachments")
 
     def __str__(self):
-        return u'%s / %s' % (self.problem.name, self.filename)
+        return '%s / %s' % (self.problem.name, self.filename)
 
 
 def _make_package_filename(instance, filename):
@@ -787,7 +787,7 @@ class OriginInfoValue(models.Model):
     @property
     def full_name(self):
         return str(
-            u'{} {}'.format(self.parent_tag.full_name, self.full_value)
+            '{} {}'.format(self.parent_tag.full_name, self.full_value)
         )
 
     class Meta(object):
@@ -855,7 +855,7 @@ class DifficultyTagThrough(models.Model):
 
     # This string will be visible in an admin form.
     def __str__(self):
-        return str(self.problem.name) + u' -- ' + str(self.tag.name)
+        return str(self.problem.name) + ' -- ' + str(self.tag.name)
 
 
 
@@ -888,7 +888,7 @@ class DifficultyTagProposal(models.Model):
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
 
     def __str__(self):
-        return str(self.problem.name) + u' -- ' + str(self.tag.name)
+        return str(self.problem.name) + ' -- ' + str(self.tag.name)
 
     class Meta(object):
         verbose_name = _("difficulty proposal")
@@ -902,7 +902,7 @@ class AggregatedDifficultyTagProposal(models.Model):
     amount = models.PositiveIntegerField(default=0)
 
     def __str__(self):
-        return str(self.problem.name) + u' -- ' + str(self.tag.name) + u' -- ' + str(self.amount)
+        return str(self.problem.name) + ' -- ' + str(self.tag.name) + ' -- ' + str(self.amount)
 
     class Meta:
         verbose_name = _("aggregated difficulty tag proposal")
@@ -942,7 +942,7 @@ class AlgorithmTagThrough(models.Model):
 
     # This string will be visible in an admin form.
     def __str__(self):
-        return str(self.problem.name) + u' -- ' + str(self.tag.name)
+        return str(self.problem.name) + ' -- ' + str(self.tag.name)
 
     class Meta(object):
         unique_together = ('problem', 'tag')
@@ -978,7 +978,7 @@ class AlgorithmTagProposal(models.Model):
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
 
     def __str__(self):
-        return str(self.problem.name) + u' -- ' + str(self.tag.name)
+        return str(self.problem.name) + ' -- ' + str(self.tag.name)
 
     class Meta(object):
         verbose_name = _("algorithm tag proposal")
@@ -992,7 +992,7 @@ class AggregatedAlgorithmTagProposal(models.Model):
     amount = models.PositiveIntegerField(default=0)
 
     def __str__(self):
-        return str(self.problem.name) + u' -- ' + str(self.tag.name) + u' -- ' + str(self.amount)
+        return str(self.problem.name) + ' -- ' + str(self.tag.name) + ' -- ' + str(self.amount)
 
     class Meta:
         verbose_name = _("aggregated algorithm tag proposal")

--- a/oioioi/problems/models.py
+++ b/oioioi/problems/models.py
@@ -855,7 +855,7 @@ class DifficultyTagThrough(models.Model):
 
     # This string will be visible in an admin form.
     def __str__(self):
-        return str(self.tag.name)
+        return str(self.problem.name) + u' -- ' + str(self.tag.name)
 
 
 
@@ -942,7 +942,7 @@ class AlgorithmTagThrough(models.Model):
 
     # This string will be visible in an admin form.
     def __str__(self):
-        return str(self.tag.name)
+        return str(self.problem.name) + u' -- ' + str(self.tag.name)
 
     class Meta(object):
         unique_together = ('problem', 'tag')

--- a/oioioi/problems/tests/test_commands.py
+++ b/oioioi/problems/tests/test_commands.py
@@ -1,0 +1,242 @@
+from io import StringIO
+from django.test import TestCase, override_settings
+from django.core.management import call_command, CommandError
+from django.contrib.auth import get_user_model
+from oioioi.problems.models import (
+    Problem,
+    AlgorithmTag,
+    DifficultyTag,
+    AlgorithmTagThrough,
+    DifficultyTagThrough,
+    AlgorithmTagProposal,
+    DifficultyTagProposal,
+    ProblemSite,
+)
+
+User = get_user_model()
+
+@override_settings(DEBUG=True)
+class TestMassCreateTool(TestCase):
+    name_to_model = {
+        'problems': Problem,
+        'problems': ProblemSite,
+        'users': User,
+        'algotags': AlgorithmTag,
+        'difftags': DifficultyTag,
+        'algothrough': AlgorithmTagThrough,
+        'diffthrough': DifficultyTagThrough,
+        'algoproposals': AlgorithmTagProposal,
+        'diffproposals': DifficultyTagProposal,
+    }
+
+    def _assert_model_counts(self, expected_counts):
+        for name, model in self.name_to_model.items():
+            count = model.objects.count()
+            expected_count = expected_counts.get(name, 0)
+            assert count == expected_count, f"Expected {expected_count} {name}, got {count}" 
+
+    def test_long_flags(self):
+        out = StringIO()
+        call_command(
+            'mass_create_tool',
+            '--problems', '10',
+            '--users', '10',
+            '--algotags', '5',
+            '--difftags', '5',
+            '--algothrough', '20',
+            '--diffthrough', '8',
+            '--algoproposals', '50',
+            '--diffproposals', '50',
+            stdout=out,
+        )
+        self._assert_model_counts({
+            'problems': 10,
+            'users': 10,
+            'algotags': 5,
+            'difftags': 5,
+            'algothrough': 20,
+            'diffthrough': 8,
+            'algoproposals': 50,
+            'diffproposals': 50,
+        })
+
+        call_command(
+            'mass_create_tool',
+            '--problems', '10',
+            '--users', '10',
+            '--algotags', '5',
+            '--difftags', '5',
+            '--algothrough', '20',
+            '--diffthrough', '8',
+            '--algoproposals', '50',
+            '--diffproposals', '50',
+            '--wipe',
+            stdout=out,
+        )
+        self._assert_model_counts({
+            'problems': 10,
+            'users': 10,
+            'algotags': 5,
+            'difftags': 5,
+            'algothrough': 20,
+            'diffthrough': 8,
+            'algoproposals': 50,
+            'diffproposals': 50,
+        })
+        call_command('mass_create_tool', '--wipe')
+        self._assert_model_counts({})
+
+    def test_short_flags(self):
+        out = StringIO()
+        call_command(
+            'mass_create_tool',
+            '-p', '10',
+            '-u', '10',
+            '-at', '5',
+            '-dt', '5',
+            '-att', '20',
+            '-dtt', '8',
+            '-ap', '50',
+            '-dp', '50',
+            stdout=out,
+        )
+        self._assert_model_counts({
+            'problems': 10,
+            'users': 10,
+            'algotags': 5,
+            'difftags': 5,
+            'algothrough': 20,
+            'diffthrough': 8,
+            'algoproposals': 50,
+            'diffproposals': 50,
+        })
+        call_command(
+            'mass_create_tool',
+            '-p', '10',
+            '-u', '10',
+            '-at', '5',
+            '-dt', '5',
+            '-att', '20',
+            '-dtt', '8',
+            '-ap', '50',
+            '-dp', '50',
+            '-w',
+            stdout=out,
+        )
+
+        self._assert_model_counts({
+            'problems': 10,
+            'users': 10,
+            'algotags': 5,
+            'difftags': 5,
+            'algothrough': 20,
+            'diffthrough': 8,
+            'algoproposals': 50,
+            'diffproposals': 50,
+        })
+        call_command('mass_create_tool', '-w')
+        self._assert_model_counts({})
+
+    @override_settings(DEBUG=False)
+    def test_debug_false(self):
+        out = StringIO()
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '10',
+                '-u', '10',
+                '-at', '5',
+                '-dt', '5',
+                '-att', '20',
+                '-dtt', '8',
+                '-ap', '50',
+                '-dp', '50',
+                stdout=out,
+            )
+
+    def test_invalid_amount(self):
+        out = StringIO()
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '10',
+                '-u', '10',
+                '-at', '5',
+                '-dt', '-5',
+                '-att', '20',
+                '-dtt', '8',
+                '-ap', '50',
+                '-dp', '50',
+                stdout=out,
+            )
+
+    def test_invalid_through_amount(self):
+        out = StringIO()
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '7',
+                '-at', '5',
+                '-att', '40',
+                stdout=out,
+            )
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '7',
+                '-dt', '5',
+                '-dtt', '10',
+                stdout=out,
+            )
+
+    def test_invalid_proposal_amount(self):
+        out = StringIO()
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '1',
+                '-u', '1',
+                '-ap', '1',
+                stdout=out,
+            )
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '1',
+                '-at', '1',
+                '-ap', '1',
+                stdout=out,
+            )
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-u', '1',
+                '-at', '1',
+                '-ap', '1',
+                stdout=out,
+            )
+
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '1',
+                '-u', '1',
+                '-dp', '1',
+                stdout=out,
+            )
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-p', '1',
+                '-dt', '1',
+                '-dp', '1',
+                stdout=out,
+            )
+        with self.assertRaises(CommandError):
+            call_command(
+                'mass_create_tool',
+                '-u', '1',
+                '-dt', '1',
+                '-dp', '1',
+                stdout=out,
+            )

--- a/oioioi/problems/tests/test_commands.py
+++ b/oioioi/problems/tests/test_commands.py
@@ -240,3 +240,44 @@ class TestMassCreateTool(TestCase):
                 '-dp', '1',
                 stdout=out,
             )
+
+    def test_seed_repeatability(self):
+        out = StringIO()
+        call_command(
+            'mass_create_tool',
+            '-p', '10',
+            '-u', '10',
+            '-at', '5',
+            '-dt', '5',
+            '-att', '20',
+            '-dtt', '8',
+            '-ap', '50',
+            '-dp', '50',
+            '-s', '8518751',
+            stdout=out,
+        )
+
+        seed_snapshot = {}
+        for name, model in self.name_to_model.items():
+            seed_snapshot[name] = sorted(str(obj) for obj in model.objects.all())
+
+        call_command(
+            'mass_create_tool',
+            '-p', '10',
+            '-u', '10',
+            '-at', '5',
+            '-dt', '5',
+            '-att', '20',
+            '-dtt', '8',
+            '-ap', '50',
+            '-dp', '50',
+            '-s', '8518751',
+            '-w',
+            stdout=out,
+        )
+
+        seed_snapshot2 = {}
+        for name, model in self.name_to_model.items():
+            seed_snapshot2[name] = sorted(str(obj) for obj in model.objects.all())
+
+        self.assertEqual(seed_snapshot, seed_snapshot2)


### PR DESCRIPTION
Resolves #512. I created this tool for benchmarking #503 and generalised it so it can be a stand-alone feature. I was missing a tool like this while implementing my previous issues. There is no commit history as it is present in the #503 PR.

Currently it is able to create Problems with associated ProblemSites (necessary for them to show up in the Probset), as well as Users and Algorithm and Difficulty Tags, TagThrough records and TagProposals.