### PR TITLE
More problem operations

### DIFF
--- a/oioioi/contests/admin.py
+++ b/oioioi/contests/admin.py
@@ -384,32 +384,25 @@ class ProblemInstanceAdmin(admin.ModelAdmin):
     ordering = ('-round__start_date', 'short_name')
     actions = ['attach_problems_to_another_contest', 'assign_problems_to_a_round', 'delete_problems']
 
-    def attach_problems_to_another_contest(self, request, queryset):
+    def _attach_problem_ids_to_url(self, queryset, url_name):
+        """Helper function to create a URL with problem ids as query parameters."""
         ids = [problem.id for problem in queryset]
-
         # Attach problem ids as arguments to the URL
-        base_url = reverse('reattach_problem_contest_list')
+        base_url = reverse(url_name)
         query_string = urlencode({'ids': ','.join(str(i) for i in ids)}, doseq=True)
+        return '%s?%s' % (base_url, query_string)
 
-        return redirect('%s?%s' % (base_url, query_string))
+    def attach_problems_to_another_contest(self, request, queryset):
+        return redirect(
+            self._attach_problem_ids_to_url(queryset, 'reattach_problem_contest_list'))
 
     def assign_problems_to_a_round(self, request, queryset):
-        ids = [problem.id for problem in queryset]
-
-        # Attach problem ids as arguments to the URL
-        base_url = reverse('assign_problems_to_a_round')
-        query_string = urlencode({'ids': ','.join(str(i) for i in ids)}, doseq=True)
-
-        return redirect('%s?%s' % (base_url, query_string))
+        return redirect(
+            self._attach_problem_ids_to_url(queryset, 'assign_problems_to_a_round'))
 
     def delete_problems(self, request, queryset):
-        ids = [problem.id for problem in queryset]
-
-        # Attach problem ids as arguments to the URL
-        base_url = reverse('delete_problems')
-        query_string = urlencode({'ids': ','.join(str(i) for i in ids)}, doseq=True)
-
-        return redirect('%s?%s' % (base_url, query_string))
+        return redirect(
+            self._attach_problem_ids_to_url(queryset, 'delete_problems'))
 
     def __init__(self, *args, **kwargs):
         # creating a thread local variable to store the request

--- a/oioioi/contests/admin.py
+++ b/oioioi/contests/admin.py
@@ -382,7 +382,7 @@ class ProblemInstanceAdmin(admin.ModelAdmin):
     list_display = ('name_link', 'short_name_link', 'round', 'package', 'actions_field')
     readonly_fields = ('contest', 'problem')
     ordering = ('-round__start_date', 'short_name')
-    actions = ['attach_problems_to_another_contest', 'assign_problems_to_a_round']
+    actions = ['attach_problems_to_another_contest', 'assign_problems_to_a_round', 'delete_problems']
 
     def attach_problems_to_another_contest(self, request, queryset):
         ids = [problem.id for problem in queryset]
@@ -398,6 +398,15 @@ class ProblemInstanceAdmin(admin.ModelAdmin):
 
         # Attach problem ids as arguments to the URL
         base_url = reverse('assign_problems_to_a_round')
+        query_string = urlencode({'ids': ','.join(str(i) for i in ids)}, doseq=True)
+
+        return redirect('%s?%s' % (base_url, query_string))
+
+    def delete_problems(self, request, queryset):
+        ids = [problem.id for problem in queryset]
+
+        # Attach problem ids as arguments to the URL
+        base_url = reverse('delete_problems')
         query_string = urlencode({'ids': ','.join(str(i) for i in ids)}, doseq=True)
 
         return redirect('%s?%s' % (base_url, query_string))

--- a/oioioi/contests/fixtures/test_problem_instance_with_and_without_contests.json
+++ b/oioioi/contests/fixtures/test_problem_instance_with_and_without_contests.json
@@ -1,0 +1,21 @@
+[
+  {
+    "pk": 10,
+    "model": "contests.probleminstance",
+    "fields": {
+      "problem": 1,
+      "round": 2,
+      "short_name": "zad1",
+      "contest": "c1"
+    }
+  },
+  {
+    "pk": 20,
+    "model": "contests.probleminstance",
+    "fields": {
+      "problem": 1,
+      "round": 3,
+      "short_name": "zad2"
+    }
+  }
+]

--- a/oioioi/contests/fixtures/test_problem_with_long_id.json
+++ b/oioioi/contests/fixtures/test_problem_with_long_id.json
@@ -1,0 +1,12 @@
+[
+  {
+    "pk": 12345,
+    "model": "contests.probleminstance",
+    "fields": {
+      "problem": 1,
+      "round": 1,
+      "short_name": "zad2",
+      "contest": "c"
+    }
+  }
+]

--- a/oioioi/contests/templates/contests/delete_problems_confirm.html
+++ b/oioioi/contests/templates/contests/delete_problems_confirm.html
@@ -1,0 +1,54 @@
+{% extends "base-with-menu.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Confirm deletion" %}{% endblock %}
+
+{% block main-content %}
+
+<h1>{% trans "Confirm deletion" %}</h1>
+<p>
+    {% blocktrans %}
+    You are going to delete the following problems from the contest
+    {% endblocktrans %}
+    <strong> {{ contest.name }} </strong>
+<ul class="list-group d-inline-block">
+    {% for problem in problem_instances %}
+    <li class="list-group-item">{{ problem }}</li>
+    {% endfor %}
+</ul>
+</p>
+
+<button class="btn btn-danger mt-3" data-bs-toggle="modal" data-bs-target="#confirmDeletionModal">
+    {% trans "Delete" %}
+</button>
+<button class="btn btn-outline-secondary mt-3" onclick="history.back()">
+    {% trans "No, go back" %}
+</button>
+ 
+<div class="modal fade" id="confirmDeletionModal" tabindex="-1" aria-labelledby="confirmDeletionLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post">
+        {% csrf_token %}
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmDeletionLabel">{% trans "Confirm Deletion" %}</h5>
+        </div>
+        <div class="modal-body">
+          {% blocktrans %}Are you sure you want to delete the selected problems? This action cannot be undone.{% endblocktrans %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+          <button type="submit" class="btn btn-danger">{% trans "Confirm Deletion" %}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Include Bootstrap JS for modal functionality -->
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% endblock %}
+

--- a/oioioi/contests/templates/contests/delete_problems_confirm.html
+++ b/oioioi/contests/templates/contests/delete_problems_confirm.html
@@ -18,7 +18,7 @@
 </ul>
 </p>
 
-<button class="btn btn-danger mt-3" data-bs-toggle="modal" data-bs-target="#confirmDeletionModal">
+<button class="btn btn-danger mt-3" data-toggle="modal" data-target="#confirmDeletionModal">
     {% trans "Delete" %}
 </button>
 <button class="btn btn-outline-secondary mt-3" onclick="history.back()">
@@ -37,18 +37,12 @@
           {% blocktrans %}Are you sure you want to delete the selected problems? This action cannot be undone.{% endblocktrans %}
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Cancel" %}</button>
           <button type="submit" class="btn btn-danger">{% trans "Confirm Deletion" %}</button>
         </div>
       </form>
     </div>
   </div>
 </div>
-
-<!-- Include Bootstrap JS for modal functionality -->
-{% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-{% endblock %}
-
 {% endblock %}
 

--- a/oioioi/contests/urls.py
+++ b/oioioi/contests/urls.py
@@ -158,13 +158,11 @@ c_patterns = [
     re_path(r'^admin/', admin.contest_site.urls),
     path('archive/confirm', views.confirm_archive_contest, name='confirm_archive_contest'),
     path('unarchive/', views.unarchive_contest, name='unarchive_contest'),
-    re_path(
-        r'^assign_problems_to_a_round/$',
+    path('assign_problems_to_a_round/',
         views.assign_problems_to_a_round_view,
         name='assign_problems_to_a_round',
     ),
-    re_path(
-        r'^delete_problems/$',
+    path('delete_problems/',
         views.delete_problems_confirm_view,
         name='delete_problems',
     )

--- a/oioioi/contests/urls.py
+++ b/oioioi/contests/urls.py
@@ -162,6 +162,11 @@ c_patterns = [
         r'^assign_problems_to_a_round/$',
         views.assign_problems_to_a_round_view,
         name='assign_problems_to_a_round',
+    ),
+    re_path(
+        r'^delete_problems/$',
+        views.delete_problems_confirm_view,
+        name='delete_problems',
     )
 ]
 

--- a/oioioi/contests/views.py
+++ b/oioioi/contests/views.py
@@ -866,7 +866,7 @@ def reattach_problem_contest_list_view(request, full_list=False):
             'problem_instances': problem_instances,
             'contest_list': contests,
             'full_list': full_list,
-            'problem_ids': '%2C'.join(str(i) for i in problem_ids), # Separate the problem ids with a comma (%2C)
+            'problem_ids': '%2C'.join(str(i) for i in problem_ids.split(',')), # Separate the problem ids with a comma (%2C)
         },
     )
 

--- a/oioioi/contests/views.py
+++ b/oioioi/contests/views.py
@@ -946,6 +946,7 @@ def assign_problems_to_a_round_view(request):
     if not request.contest:
         raise SuspiciousOperation("Invalid contest")
 
+    # Check if the problem instances belong to the contest in the request
     if not _check_if_problem_instances_belong_to_contest(problem_instances, request.contest.id):
         raise SuspiciousOperation("Invalid problem instances")
 
@@ -953,10 +954,6 @@ def assign_problems_to_a_round_view(request):
     if not request.contest.round_set.exists():
         messages.error(request, _("The contest has no rounds."))
         return redirect('oioioiadmin:contests_probleminstance_changelist')
-
-    # Check if the problem instances belong to the contest in the request
-    if not all(pi.contest and pi.contest.id == request.contest.id for pi in problem_instances):
-        raise SuspiciousOperation("Invalid problem instances")
 
     if request.method == 'POST':
         form = RoundSelectionForm(request.POST, contest=request.contest)
@@ -992,6 +989,53 @@ def assign_problems_to_a_round_view(request):
             'form': form,
         },
     )
+
+@enforce_condition(contest_exists & is_contest_basicadmin)
+def delete_problems_confirm_view(request):
+    """
+    Handles the assignment of problem instances to a specific round within a contest.
+    This view retrieves problem instances based on the provided IDs in the request,
+    validates their association with the current contest, and allows the user to assign
+    them to a specific round within the contest. If the assignment is successful, the
+    user is redirected to the problem instance changelist page.
+    Args:
+        request (HttpRequest): The HTTP request object containing GET or POST data.
+    Raises:
+        SuspiciousOperation: If the contest in the request is invalid, or if the problem
+                             instances or selected round do not belong to the contest.
+    """
+
+    problem_ids = request.GET.get('ids')
+
+    # Get the problems instances from the request
+    problem_instances = _get_problem_instances_from_problem_ids(problem_ids)
+
+    if not request.contest:
+        raise SuspiciousOperation("Invalid contest")
+
+    if not _check_if_problem_instances_belong_to_contest(problem_instances, request.contest.id):
+        raise SuspiciousOperation("Invalid problem instances")
+
+    if request.method == 'POST':
+        for problem_instance in problem_instances:
+            problem_instance.delete()
+        messages.success(request, _("Problems deleted successfully."))
+        return safe_redirect(
+            request,
+            reverse(
+                'oioioiadmin:contests_probleminstance_changelist',
+                kwargs={'contest_id': request.contest.id},
+            ),
+        )
+
+    return TemplateResponse(
+        request,
+        'contests/delete_problems_confirm.html',
+        {
+            'problem_instances': problem_instances,
+        },
+    )
+
 
 @enforce_condition(contest_exists & is_contest_basicadmin)
 def confirm_archive_contest(request):


### PR DESCRIPTION
This pull request:

- Adds removing problems in bulk conveniently by selecting problems from a list. It's related to [this](https://github.com/sio2project/oioioi/issues/508) issue.
- Refactors the code for admin actions for multiple problems by delegating most of the work to a single method (DRY principle).
- Fixes a bug with forwarding problem ids digit by digit instead of all at once when reattaching problems. This small issue was introduced in [this](https://github.com/sio2project/oioioi/pull/511) PR. When we forward url arguments, let's say ids=15,12, they would be forwarded digit by digit (ids=1,5,1,2), which is not the intended behaviour. Now it works again.
- Adds tests for the newly introduced feature of deleting problems.

Update (7.06): It also adds:
- Tests that reproduce the forwarding-problem-ids-digit-by-digit problem.
- A confirmation pop-up which appears when the user is trying to delete problems. The pop-up is compatible with the version of Bootstrap used in the project.