### PR TITLE
Removing round will not remove problems

### DIFF
--- a/oioioi/contests/models.py
+++ b/oioioi/contests/models.py
@@ -465,7 +465,7 @@ class ProblemInstance(models.Model):
         on_delete=models.CASCADE,
     )
     round = models.ForeignKey(
-        Round, verbose_name=_("round"), null=True, blank=True, on_delete=models.CASCADE
+        Round, verbose_name=_("round"), null=True, blank=True, on_delete=models.SET_NULL
     )
     problem = models.ForeignKey(
         'problems.Problem', verbose_name=_("problem"), on_delete=models.CASCADE

--- a/oioioi/contests/tests/tests.py
+++ b/oioioi/contests/tests/tests.py
@@ -3671,6 +3671,27 @@ class TestDeletingProblems(TestCase):
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 400)
 
+class TestRemovingRoundDoesNotRemoveProblems(TestCase):
+    fixtures = [
+        'test_contest',
+        'test_full_package',
+        'test_problem_instance'
+    ]
+
+    def test_removing_round_does_not_remove_problems(self):
+        round = Round.objects.get(id=1)
+        problem = ProblemInstance.objects.get(id=1)
+
+        self.assertEqual(problem.contest.id, 'c')
+        self.assertEqual(round.id, problem.round.id)
+
+        round.delete()
+
+        problem.refresh_from_db()
+        self.assertIsNone(problem.round)
+        self.assertEqual(problem.contest.id, 'c')
+
+
 class TestModifyContest(TestCase):
     fixtures = ['test_users']
 


### PR DESCRIPTION
Fixes [this](https://github.com/sio2project/oioioi/issues/520) issue.

Changes:
 - Changed the behaviour of the `ProblemInstance` model in case the object pointed to by its foreign key `round` is deleted from CASCADE to SET_NULL, which produces the desired behaviour.
 - Added a test to replicate the problem