### PR TITLE
Fix: Docker build failure (ModuleNotFoundError) and cypress tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,22 +58,17 @@ RUN pip3 install --user bsddb3==6.2.7
 
 WORKDIR /sio2/oioioi
 
-COPY --chown=oioioi:oioioi setup.py requirements.txt ./
-RUN pip3 install -r requirements.txt --user filetracker[server]
-COPY --chown=oioioi:oioioi requirements_static.txt ./
-RUN pip3 install -r requirements_static.txt --user
+COPY --chown=oioioi:oioioi . ./
+RUN pip3 install --user -r requirements.txt filetracker[server]
+RUN pip3 install --user -r requirements_static.txt
 RUN pip3 install --user -U "gevent==25.5.1"  # override version of gevent
 
 # Installing node dependencies
 ENV PATH $PATH:/sio2/oioioi/node_modules/.bin
 
-COPY --chown=oioioi:oioioi package.json package-lock.json ./
 RUN npm ci
-
-COPY --chown=oioioi:oioioi . /sio2/oioioi
-
 RUN npm run build
-RUN pip3 install --user -e .
+
 RUN oioioi-create-config /sio2/deployment
 
 WORKDIR /sio2/deployment

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ WORKDIR /sio2/oioioi
 COPY --chown=oioioi:oioioi . ./
 RUN pip3 install --user -r requirements.txt filetracker[server]
 RUN pip3 install --user -r requirements_static.txt
-RUN pip3 install --user -U "gevent==25.5.1"  # override version of gevent
 
 # Installing node dependencies
 ENV PATH $PATH:/sio2/oioioi/node_modules/.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN npm ci
 COPY --chown=oioioi:oioioi . /sio2/oioioi
 
 RUN npm run build
+RUN pip3 install --user -e .
 RUN oioioi-create-config /sio2/deployment
 
 WORKDIR /sio2/deployment

--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -45,7 +45,7 @@ RAW_COMMANDS = [
         "Run coverage tests.",
         "{exec} 'web' ../oioioi/test.sh oioioi/problems --cov-report term --cov-report xml:coverage.xml --cov=oioioi {extra_args}",
     ),
-    ("cypress-apply-settings", "Apply settings for CyPress.", '{exec} web bash -c "echo CAPTCHA_TEST_MODE=True >> settings.py"'),
+    ("cypress-apply-settings", "Apply settings for CyPress.", '{exec} web bash -c "echo >> settings.py && echo CAPTCHA_TEST_MODE=True >> settings.py"'),
     ("npm", "Run npm command.", "{exec} web npm --prefix ../oioioi {extra_args}"),
     ("eslint", "Run javascript linter.", "{exec} web npm --prefix ../oioioi run lint"),
     (


### PR DESCRIPTION
For some strange reason, the [docker build action](https://github.com/sio2project/oioioi/blob/master/.github/workflows/build.yml) along with the [cypress tests action](https://github.com/sio2project/oioioi/blob/master/.github/workflows/cypress.yml) stopped working on Jun 18. A fix was made https://github.com/sio2project/oioioi/commit/50657ed17f02f255e21e8310de34bb415e400a98 - but it didn't help with Cypress, only with the docker build action. Unfortunately, as it turns out, the docker build action (including Cypress) still doesn't work due to another error:

```
0.280 Traceback (most recent call last):
0.280   File "/home/oioioi/.local/bin/oioioi-create-config", line 5, in <module>
0.280     from oioioi.deployment.create_config import main
0.280 ModuleNotFoundError: No module named 'oioioi'
```

This error probably didn't exist before, but now it does because of the installation of a newer version of `setuptools` through dependencies.

Long-term, it would be advisable to stop using `setup.py` in place of `pyproject.toml` and gently modernize the build process.