### PR TITLE
Fixed LaTeX in html statements is unreadable in dark mode (#543)

### DIFF
--- a/oioioi/base/static/js/darkreader.js
+++ b/oioioi/base/static/js/darkreader.js
@@ -1,7 +1,13 @@
 import { enable, disable } from 'darkreader';
 
+const darkModeConfig = {
+  fixes: {
+    css: '.texmath img { filter: invert(1) brightness(0.8) !important; }'
+  }
+};
+
 if (localStorage.getItem("dark-mode") === "enabled") {
-  enable();
+  enable({}, darkModeConfig.fixes);
 }
 
 document.addEventListener("DOMContentLoaded", function () {
@@ -11,7 +17,7 @@ document.addEventListener("DOMContentLoaded", function () {
           disable();
           localStorage.setItem("dark-mode", "disabled");
       } else {
-          enable();
+          enable({}, darkModeConfig.fixes);
           localStorage.setItem("dark-mode", "enabled");
       }
   });


### PR DESCRIPTION
Fixed unreadable LaTeX in html statements by adding a css invert filter to the darkreader config variable. Also added an 80% brightness filter to match the color with rest of the text.