### PR TITLE
Replace file reading with dummy file content, relate to #575

### DIFF
--- a/oioioi/problems/tests/test_problem.py
+++ b/oioioi/problems/tests/test_problem.py
@@ -1,4 +1,3 @@
-import six
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission, User
 from django.contrib.contenttypes.models import ContentType
@@ -170,13 +169,10 @@ class TestProblemViews(TestCase, TestStreamingMixin):
         contest = Contest.objects.get()
         statement = ProblemStatement.objects.get()
 
-        with open(__file__, "rb") as f:
-            file = six.ensure_text(f.read())
-
         check_not_accessible(
             self,
             "oioioiadmin:problems_problem_add",
-            data={"package_file": file, "contest_id": contest.id},
+            data={"package_file": "dummy_file_content", "contest_id": contest.id},
         )
         check_not_accessible(
             self,


### PR DESCRIPTION
Line 172: Access should be denied before any file is accessed. Thereupon long file name can be replaced by "Dummyname". Thanks to that error 400 (to many charakters in url) doesn't occur.