### PR TITLE
Upgraded the warnings in easy-toolbox.py

### DIFF
--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -32,7 +32,7 @@ RAW_COMMANDS = [
         "build",
         "Build OIOIOI container from source.",
         "build",
-        "This will rebuild the project, data will be lost.",
+        "This may result in the loss of local modifications inside containers.",
     ),
     ("up", "Run all SIO2 containers", "up -d"),
     ("down", "Stop and remove all SIO2 containers", "down"),


### PR DESCRIPTION
The warnings in easy-toolbox are now action-specific rather than the same, default "marked as dangerous" warning. They now try to inform the user of the consequences of their actions (rather than, for example, saying that "build" is dangerous without telling the user that it's dangerous because it overrides the build).