### PR TITLE
Automatic node modules actualization

### DIFF
--- a/oioioi_init.sh
+++ b/oioioi_init.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-/sio2/oioioi/wait-for-it.sh -t 60 "db:5432"
+/sio2/oioioi/wait-for-it.sh -t 60 "${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}"
 
 if [ "$1" == "--dev" ]; then
     echo "Checking frontend dependencies..."

--- a/oioioi_init.sh
+++ b/oioioi_init.sh
@@ -2,9 +2,21 @@
 set -e
 set -x
 
-/sio2/oioioi/wait-for-it.sh -t 60 "${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}"
+/sio2/oioioi/wait-for-it.sh -t 60 "db:5432"
 
 if [ "$1" == "--dev" ]; then
+    echo "Checking frontend dependencies..."
+
+    if ! (cd ../oioioi && npm list --depth=0 > /dev/null 2>&1); then
+        echo "Dependencies mismatch or missing. Running npm install..."
+        (cd ../oioioi && npm install)
+    else
+        echo "Dependencies are up to date."
+    fi
+
+    echo "Building frontend assets..."
+    (cd ../oioioi && npm run build)
+
     ./manage.py migrate 2>&1 | tee /sio2/deployment/logs/migrate.log
     ./manage.py loaddata ../oioioi/extra/dbdata/default_admin.json
 


### PR DESCRIPTION
This pull request fixes the problem where web container crashes after MathJax's git pull because of missing node_modules.

When running docker-compose, the local folder (volume) overrides the files inside the container. Because of this, `node_modules` was missing 'copy-webpack-plugin' and the server didn't start.

The fix:
I updated `oioioi_init.sh`: I added a dependancies check using: `npm list --depth=0`:

1. When you start the container (`up`), it checks if your installed packages match `package.json`.
2. If `npm list` returns an error (missing files or wrong version), it runs `npm install` inside the container automatically.
3. Then it runs `npm run build` to copy assets.

This should work for any new library we add in the future, not just MathJax.
Note: you may need to take your's containers down before you make them up using my version of oioioi_init.sh.