### PR TITLE
submit another testrun redirect

### DIFF
--- a/oioioi/contests/templates/contests/submission_header.html
+++ b/oioioi/contests/templates/contests/submission_header.html
@@ -52,7 +52,11 @@
             {% if not is_contest_archived %}
                 <a role="button"
                     class="btn btn-sm btn-outline-secondary"
-                    href= "{% url 'submit' contest_id=contest.id problem_instance_id=submission.submission.problem_instance.id %}">
+                    {% if submission.submission.kind == "TESTRUN" %}
+                        href= "{% url 'testrun_submit' contest_id=contest.id problem_instance_id=submission.submission.problem_instance.id %}">
+                    {% else %}
+                        href= "{% url 'submit' contest_id=contest.id problem_instance_id=submission.submission.problem_instance.id %}">
+                    {% endif %}
                     <i class="fa-regular fa-circle-up"></i>
                     {% trans "Submit another" %}
             {% endif %}

--- a/oioioi/testrun/tests.py
+++ b/oioioi/testrun/tests.py
@@ -33,6 +33,7 @@ class TestTestrunViews(TestCase):
     ]
 
     def test_status_visible(self):
+        contest = Contest.objects.get()
         self.assertTrue(self.client.login(username="test_user"))
         submission = TestRunProgramSubmission.objects.get(pk=1)
         kwargs = {
@@ -45,6 +46,17 @@ class TestTestrunViews(TestCase):
             self.assertContains(submission_view, "Input")
             self.assertContains(submission_view, "Output")
             self.assertContains(submission_view, "OK")
+
+            # Submit another button
+            submit_url = reverse(
+                "testrun_submit",
+                kwargs={
+                    "contest_id": contest.id,
+                    "problem_instance_id": submission.problem_instance.id,
+                },
+            )
+            self.assertContains(submission_view, submit_url)
+
             submission_view = self.client.get(
                 reverse(
                     "my_submissions",

--- a/oioioi/testrun/urls.py
+++ b/oioioi/testrun/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, re_path
 
 from oioioi.testrun import views
 
@@ -6,6 +6,11 @@ app_name = "testrun"
 
 contest_patterns = [
     path("testrun_submit/", views.testrun_submit_view, name="testrun_submit"),
+    re_path(
+        r"^testrun_submit/(?P<problem_instance_id>[a-z0-9_-]+)/$",
+        views.testrun_submit_view,
+        name="testrun_submit",
+    ),
     path(
         "s/<int:submission_id>/tr/input/",
         views.show_input_file_view,

--- a/oioioi/testrun/views.py
+++ b/oioioi/testrun/views.py
@@ -30,7 +30,7 @@ from oioioi.testrun.utils import (
 )
 @enforce_condition(contest_exists & can_enter_contest)
 @enforce_condition(has_any_testrun_problem, template="testrun/no-testrun-problems.html")
-def testrun_submit_view(request):
+def testrun_submit_view(request, problem_instance_id=None):
     if request.method == "POST":
         form = SubmissionForm(
             request,
@@ -43,7 +43,10 @@ def testrun_submit_view(request):
             request.contest.controller.create_testrun(request, form.cleaned_data["problem_instance"], form.cleaned_data)
             return redirect("my_submissions", contest_id=request.contest.id)
     else:
-        form = SubmissionForm(request, kind="TESTRUN", problem_filter=filter_testrun_problem_instances)
+        initial = {}
+        if problem_instance_id is not None:
+            initial = {"problem_instance_id": int(problem_instance_id)}
+        form = SubmissionForm(request, kind="TESTRUN", problem_filter=filter_testrun_problem_instances, initial=initial)
 
     problem_instances = filter_testrun_problem_instances(form.get_problem_instances())
 


### PR DESCRIPTION
Now the submit another button in a testrun submission redirects to the submit testrun page (instead of the normal submission page).