### PR TITLE
Add mock data creation to easy toolbox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,19 @@ If you want to check all files, not just the modified ones, you can run::
 
      pre-commit run --all-files
 
+Creating mock data (for development)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To quickly populate your development environment with sample data, you can use the following commands::
+
+    ./easy_toolbox.py populate-sample-data
+
+This creates a contest with a sample problem package and 10 users, each with 3 submissions.
+
+To remove all the data created by the above command (and any data created by the mass_create_tool)::
+
+    ./easy_toolbox.py wipe-sample-data
+
 Manual installation (deprecated)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -76,12 +76,12 @@ RAW_COMMANDS = [
     ),
     (
         "populate-sample-data",
-        "Creates a contest with the sample problem package and 10 users, with 3 submissions each.",
+        "Create a contest with the sample problem package and 10 users, with 3 submissions each.",
         "{exec} web python manage.py mass_create_tool -cn demo -cc -pp test_full_package.tgz -u 10 -sf sum-correct.cpp sum-various-results.cpp -spu 3 -v 0",
     ),
     (
         "wipe-sample-data",
-        "Wipes all contests, problems, users and submissions created with `populate-sample-data`.",
+        "Wipe all contests, problems, users and submissions created with `populate-sample-data`.",
         "{exec} web python manage.py mass_create_tool --wipe",
         "Warning: This will wipe all data created using the mass_create_tool. Are you sure you want to proceed?"
     )

--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -74,6 +74,17 @@ RAW_COMMANDS = [
         "Run Ruff, a linter and formatter. You can add `--fix` to automatically fix some errors.",
         "{exec} -w /sio2/oioioi web bash -c 'ruff check . {extra_args} ; echo ; ruff format .'",
     ),
+    (
+        "populate-sample-data",
+        "Creates a contest with the sample problem package and 10 users, with 3 submissions each.",
+        "{exec} web python manage.py mass_create_tool -cn demo -cc -pp test_full_package.tgz -u 10 -sf sum-correct.cpp sum-various-results.cpp -spu 3 -v 0",
+    ),
+    (
+        "wipe-sample-data",
+        "Wipes all contests, problems, users and submissions created with `populate-sample-data`.",
+        "{exec} web python manage.py mass_create_tool --wipe",
+        "Warning: This will wipe all data created using the mass_create_tool. Are you sure you want to proceed?"
+    )
 ]
 
 longest_command_arg = max([len(command[0]) for command in RAW_COMMANDS])


### PR DESCRIPTION
Previously, generating mock data was possible by invoking the mass_create_tool through the web container command prompt.
(https://github.com/sio2project/oioioi/pull/604).

Thic commit adds a layer of abstraction over the mass_create_tool, by adding the "populate-sample-data" and "wipe-sample-data" commands to the easy toolbox, thus making synthetic data generation very simple. This will b euseful in testing development changes.

As per TAG's standup, this PR is not linked to an issue, as it is fairly small. 