### PR TITLE
Fixed the build failing due to coreapi relying on setuptools features removed in 82.0.0

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -35,4 +35,5 @@ runs:
   - name: Install python dependencies
     run: |
       uv pip install -r requirements.txt
+      uv pip install "setuptools<81"
     shell: sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ RUN uv pip install -r requirements.txt filetracker[server]
 RUN uv pip install -r requirements_static.txt
 
 # Pin the version of setuptools to <81 because of the outdated coreapi package
-RUN uv pip uninstall setuptools
 RUN uv pip install "setuptools<81"
 
 # Installing node dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN uv pip install -r requirements.txt filetracker[server]
 RUN uv pip install -r requirements_static.txt
 
 # Pin the version of setuptools to <81 because of the outdated coreapi package
+RUN uv pip uninstall setuptools
 RUN uv pip install "setuptools<81"
 
 # Installing node dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ COPY --chown=oioioi:oioioi . ./
 RUN uv pip install -r requirements.txt filetracker[server]
 RUN uv pip install -r requirements_static.txt
 
+# Pin the version of setuptools to <81 because of the outdated coreapi package
+RUN uv pip install "setuptools<81"
+
 # Installing node dependencies
 ENV PATH=$PATH:/sio2/oioioi/node_modules/.bin
 


### PR DESCRIPTION
The (temporary) solution is to pin the setuptools version to be <81 as recommended by setuptools itself.

The long-term solution is to migrate from CoreAPI to OpenAPI. According to the CoreAPI github page:
<img width="866" height="216" alt="image" src="https://github.com/user-attachments/assets/0a4ef153-ff14-4b7f-8de2-66a823940fee" />

Closes #621.

I will create an issue and try to perform the migration later since the project's usage of CoreAPI is very limited and I am hoping that it shouldn't be too difficult.