### PR TITLE
Replace randomize_time with fake_time in environment configuration

### DIFF
--- a/oioioi/programs/controllers.py
+++ b/oioioi/programs/controllers.py
@@ -163,7 +163,7 @@ class ProgrammingProblemController(ProblemController):
         environ["compiler"] = problem_instance.controller.get_compiler_for_submission(submission)
 
         config = ExtraConfig.objects.get(problem_id=problem.id)
-        environ["randomize_time"] =  config.parsed_config.get("randomize_time", False)
+        environ["fake_time"] = config.parsed_config.get("fake_time", "off")
 
     def generate_base_environ(self, environ, submission, **kwargs):
         self.generate_initial_evaluation_environ(environ, submission)


### PR DESCRIPTION
Slight change in the behavior of sio2jail (now allows returning zeros or random values)