### PR TITLE
Update ctimes for recent oi-timer use scenarios

### DIFF
--- a/oioioi/ctimes/README.rst
+++ b/oioioi/ctimes/README.rst
@@ -1,2 +1,10 @@
 A module implementing an interface for delivering round start
-and end times encoded as JSON.
+and end times encoded as JSON. Used for locking contestants' computers
+before or after a round with oi-timer.
+
+The logic for choosing the round to return info about is as follows:
+1. Discard rounds that ended more than 5 minutes ago.
+2. Of ongoing rounds, return the one ending first.
+3. Of rounds starting in the next 5 minutes, return the earliest starting one.
+4. Of recently ended rounds, return the one that ended last.
+5. Of future rounds, return the earliest starting one.

--- a/oioioi/ctimes/tests.py
+++ b/oioioi/ctimes/tests.py
@@ -27,6 +27,39 @@ class TestCtimes(TestCase):
                 end_date=datetime(2013, 11, 5, 11, 0, tzinfo=UTC),
             ),
             Round(
+                name="round3",
+                contest=contest1,
+                start_date=datetime(2014, 1, 1, 1, 0, tzinfo=UTC),
+                end_date=datetime(2014, 1, 1, 2, 0, tzinfo=UTC),
+            ),
+            # Starts 7 minutes after round3 ends.
+            Round(
+                name="round4",
+                contest=contest1,
+                start_date=datetime(2014, 1, 1, 2, 7, tzinfo=UTC),
+                end_date=None,
+            ),
+            # For testing comparisons with rounds without ends
+            # and between recently-ended rounds.
+            Round(
+                name="round5",
+                contest=contest1,
+                start_date=datetime(2015, 1, 1, tzinfo=UTC),
+                end_date=datetime(2016, 1, 1, tzinfo=UTC),
+            ),
+            Round(
+                name="round6",
+                contest=contest1,
+                start_date=datetime(2015, 1, 1, tzinfo=UTC),
+                end_date=datetime(2016, 1, 1, 0, 0, 1, tzinfo=UTC),
+            ),
+            Round(
+                name="round7",
+                contest=contest1,
+                start_date=datetime(2015, 1, 2, tzinfo=UTC),
+                end_date=datetime(2016, 1, 1, tzinfo=UTC),
+            ),
+            Round(
                 name="round1p",
                 contest=contest2,
                 start_date=datetime(2014, 1, 2, 3, 10, tzinfo=UTC),
@@ -49,6 +82,46 @@ class TestCtimes(TestCase):
             "end": "2013-11-05 11:00:00",
             "end_sec": 1383649200,
         }
+        self.round3_result = {
+            "status": "OK",
+            "round_name": "round3",
+            "start": "2014-01-01 01:00:00",
+            "start_sec": 1388538000,
+            "end": "2014-01-01 02:00:00",
+            "end_sec": 1388541600,
+        }
+        self.round4_result = {
+            "status": "OK",
+            "round_name": "round4",
+            "start": "2014-01-01 02:07:00",
+            "start_sec": 1388542020,
+            "end": None,
+            "end_sec": None,
+        }
+        self.round5_result = {
+            "status": "OK",
+            "round_name": "round5",
+            "start": "2015-01-01 00:00:00",
+            "start_sec": 1420070400,
+            "end": "2016-01-01 00:00:00",
+            "end_sec": 1451606400,
+        }
+        self.round6_result = {
+            "status": "OK",
+            "round_name": "round6",
+            "start": "2015-01-01 00:00:00",
+            "start_sec": 1420070400,
+            "end": "2016-01-01 00:00:01",
+            "end_sec": 1451606401,
+        }
+        self.round7_result = {
+            "status": "OK",
+            "round_name": "round7",
+            "start": "2015-01-02 00:00:00",
+            "start_sec": 1420156800,
+            "end": "2016-01-01 00:00:00",
+            "end_sec": 1451606400,
+        }
         self.round1p_result = {
             "status": "OK",
             "round_name": "round1p",
@@ -60,19 +133,55 @@ class TestCtimes(TestCase):
         Round.objects.bulk_create(rounds)
         self.assertTrue(self.client.login(username="test_user"))
 
+    def verify_result(self, url, result):
+        response = self.client.get(url).json()
+        self.assertEqual(response, result)
+
     def test_ctimes_order(self):
         url = reverse("ctimes", kwargs={"contest_id": "c1"})
         self.client.get(url)
         with fake_time(datetime(2013, 10, 1, 21, tzinfo=UTC)):
-            response = self.client.get(url).json()
-            self.assertEqual(response, self.round2_result)
+            self.verify_result(url, self.round1_result)
         with fake_time(datetime(2013, 10, 11, 7, 56, tzinfo=UTC)):
-            response = self.client.get(url).json()
-            self.assertEqual(response, self.round1_result)
+            self.verify_result(url, self.round1_result)
         with fake_time(datetime(2013, 10, 22, 9, 56, tzinfo=UTC)):
-            response = self.client.get(url).json()
-            self.assertEqual(response, self.round1_result)
-        with fake_time(datetime(2013, 12, 11, 5, 0, tzinfo=UTC)):
+            self.verify_result(url, self.round1_result)
+        with fake_time(datetime(2013, 10, 22, 10, tzinfo=UTC)):
+            self.verify_result(url, self.round2_result)
+        with fake_time(datetime(2013, 11, 5, 11, 1, tzinfo=UTC)):
+            self.verify_result(url, self.round1_result)
+        # Just after round2 ends:
+        with fake_time(datetime(2013, 12, 5, 9, 1, tzinfo=UTC)):
+            self.verify_result(url, self.round1_result)
+        with fake_time(datetime(2013, 12, 5, 9, 5, tzinfo=UTC)):
+            self.verify_result(url, self.round1_result)
+        with fake_time(datetime(2013, 12, 5, 9, 6, tzinfo=UTC)):
+            self.verify_result(url, self.round3_result)
+        with fake_time(datetime(2014, 1, 1, 0, 1, tzinfo=UTC)):
+            self.verify_result(url, self.round3_result)
+        with fake_time(datetime(2014, 1, 1, 1, 0, tzinfo=UTC)):
+            self.verify_result(url, self.round3_result)
+        with fake_time(datetime(2014, 1, 1, 2, 1, tzinfo=UTC)):
+            self.verify_result(url, self.round3_result)
+        # Round3 just ended, but round4 starts in 5 minutes.
+        with fake_time(datetime(2014, 1, 1, 2, 2, tzinfo=UTC)):
+            self.verify_result(url, self.round4_result)
+        with fake_time(datetime(2014, 1, 1, 2, 30, tzinfo=UTC)):
+            self.verify_result(url, self.round4_result)
+        # Since round4 is ongoing, no info about round5 should be shown.
+        with fake_time(datetime(2014, 12, 31, 23, 59, 59, tzinfo=UTC)):
+            self.verify_result(url, self.round4_result)
+        # Rounds 5-6 just started. They end earlier than round4,
+        # round5 ends a second earlier than round6.
+        with fake_time(datetime(2015, 1, 1, 0, tzinfo=UTC)):
+            self.verify_result(url, self.round5_result)
+        Round.objects.get(name="round4").delete()
+        with fake_time(datetime(2014, 1, 1, 2, 5, tzinfo=UTC)):
+            self.verify_result(url, self.round3_result)
+        # Rounds 5-7 just ended, but round6 did so a second later.
+        with fake_time(datetime(2016, 1, 1, 0, 1, tzinfo=UTC)):
+            self.verify_result(url, self.round6_result)
+        with fake_time(datetime(2016, 1, 1, 1, tzinfo=UTC)):
             response = self.client.get(url).json()
             self.assertEqual(response["status"], "NO_ROUND")
         Contest.objects.all().delete()
@@ -96,6 +205,7 @@ class TestCtimes(TestCase):
         rnd = Round.objects.get(name="round1")
         user = User.objects.get(username="test_user")
         RoundTimeExtension.objects.create(round=rnd, user=user, extra_time=5)
+        Round.objects.exclude(name="round1").delete()
         with fake_time(datetime(2013, 10, 11, 7, 56, tzinfo=UTC)):
             response = self.client.get(url).json()
             self.assertEqual(

--- a/oioioi/ctimes/views.py
+++ b/oioioi/ctimes/views.py
@@ -15,21 +15,26 @@ def ctimes_view(request):
     if contest is None:
         return {"status": "NO_CONTEST"}
 
-    def end_le(a, b):
-        """Compare round ends. None means "round does not end",
-        so it ends not earlier than any other."""
-        return True if b is None else b >= a
+    def get_end(rtime):
+        """Get round end for comparisons. None means "round does not end",
+        so in comparisons it shouldn't be earlier than any other."""
+        return rtime.get_key_for_comparison()[1]
 
     ccontroller = contest.controller
     rounds = [(ccontroller.get_round_times(request, round), round) for round in Round.objects.filter(contest=request.contest)]
-    rounds = [(rtime, round) for (rtime, round) in rounds if end_le(now - timedelta(minutes=30), rtime.get_end())]
+
+    end_cutoff = now - timedelta(minutes=5)
+    rounds = [(rtime, round) for (rtime, round) in rounds if not rtime.is_past(end_cutoff)]
 
     def ctimes_sort_key(round_time):
-        return (
-            not (round_time.get_start() <= now and end_le(now, round_time.get_end())),
-            not round_time.get_start() - timedelta(minutes=5) <= now,
-            round_time.get_end(),
-        )
+        # See README.rst for an explanation of the ordering.
+        if round_time.is_active(now):
+            return (0, get_end(round_time))
+        if round_time.is_past(now):
+            # Of past rounds, we want the one that ended last.
+            return (2, now - get_end(round_time))
+        starts_soon = not round_time.is_future(now + timedelta(minutes=5))
+        return (1 if starts_soon else 3, round_time.get_start())
 
     try:
         (rtime, round) = min(rounds, key=lambda x: ctimes_sort_key(x[0]))


### PR DESCRIPTION
For context: the `ctimes` view's main (only?) purpose is supplying round time data to `oi-timer`, which is used at onsite competitions to lock the participants' computers before the round starts. It seems that a long time ago it was also used to lock computers after a round ended.

Previous behaviour - of rounds matching the given condition, the one ending first is shown:
1. Ongoing rounds.
2. Rounds that ended in the last 30 minutes.
3. Rounds starting in the next 5 minutes.
4. Rounds that have not started yet.

The main issue with this logic is that one can't use oi-timer
in the 30 minutes following the end of a round. This required manually moving the end of the last round further into the past, which was (at least this year) done between:
- the trial and main OIJ rounds
- the "computer acceptation" and trial OI rounds,

which have only short breaks between them.

Also, returning the soonest ending round when none are ongoing is weird if there were rounds like 2027-2030 and 2028-2029.

The new logic is as follows:
1. Discard rounds that ended more than 5 minutes ago.
2. Of ongoing rounds, return the one ending first.
3. Of rounds starting in the next 5 minutes, return the earliest starting one.
4. Of recently ended rounds, return the one that ended last.
5. Of future rounds, return the earliest starting one.

Returning recently ended rounds is useful for locking computers after the round ends, though that wasn't done in the last few years.

The details of the ordering for overlapping rounds are mostly guesses as to which round data would be needed for `oi-timer`, since, to my best knowledge, it was never used in such scenarios.

Additionally, a leftover (from `16ce59`) bug in `ctimes_sort_key` related to unset round ends has been fixed.