### PR TITLE
fix: hide user name in forum votes for anonymous contest registrations

### DIFF
--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -15,7 +15,8 @@ def display_reacted_by(context, post, rtype):
 
     request = context.get('request')
     if request and hasattr(request, 'contest'):
-        get_name = lambda user: request.contest.controller.get_user_public_name(request, user)
+        def get_name(user):
+            return request.contest.controller.get_user_public_name(request, user)
     else:
         get_name = get_user_display_name
 

--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -13,8 +13,9 @@ def display_reacted_by(context, post, rtype):
     if rtype not in POST_REACTION_TO_PREFETCH_ATTR:
         raise ValueError("Invalid reaction type in template:" + rtype)
 
-    request = context.get('request')
-    if request and hasattr(request, 'contest'):
+    request = context.get("request")
+    if request and hasattr(request, "contest"):
+        
         def get_name(user):
             return request.contest.controller.get_user_public_name(request, user)
     else:

--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -15,7 +15,7 @@ def display_reacted_by(context, post, rtype):
 
     request = context.get("request")
     if request and hasattr(request, "contest"):
-        
+
         def get_name(user):
             return request.contest.controller.get_user_public_name(request, user)
     else:

--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -8,12 +8,18 @@ from oioioi.forum.models import POST_REACTION_TO_COUNT_ATTR, POST_REACTION_TO_PR
 register = template.Library()
 
 
-@register.simple_tag
-def display_reacted_by(post, rtype):
+@register.simple_tag(takes_context=True)
+def display_reacted_by(context, post, rtype):
     if rtype not in POST_REACTION_TO_PREFETCH_ATTR:
         raise ValueError("Invalid reaction type in template:" + rtype)
 
-    output = ", ".join([get_user_display_name(reaction.author) for reaction in getattr(post, POST_REACTION_TO_PREFETCH_ATTR[rtype])])
+    request = context.get('request')
+    if request and hasattr(request, 'contest'):
+        get_name = lambda user: request.contest.controller.get_user_public_name(request, user)
+    else:
+        get_name = get_user_display_name
+
+    output = ", ".join([get_name(reaction.author) for reaction in getattr(post, POST_REACTION_TO_PREFETCH_ATTR[rtype])])
 
     count = getattr(post, POST_REACTION_TO_COUNT_ATTR[rtype])
     max_count = getattr(settings, "FORUM_REACTIONS_TO_DISPLAY", 10)


### PR DESCRIPTION
A bug fix for the OIOIOI forum
Reaction lists (the "reacted by" section on posts) were showing participants' full real names even when they'd registered anonymously for a contest. The fix hooks the template tag into the contest's existing anonymity logic, so anonymous participants now only appear by username. If there's no contest context at all, it falls back to the old behavior as a safety net.