### PR TITLE
'Reveal limit' hover message is visible only after long delay

### DIFF
--- a/oioioi/base/templates/admin/edit_inline/tabular.html
+++ b/oioioi/base/templates/admin/edit_inline/tabular.html
@@ -21,7 +21,7 @@
          {% for field in inline_admin_formset.fields %}
            {% if not field.widget.is_hidden %}
              <th class="column-{{ field.name }}{% if field.required %} required{% endif %}">{{ field.label|capfirst }}
-             {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="14" height="14" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+             {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="14" height="14" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" data-toggle="tooltip">{% endif %}
              </th>
            {% endif %}
          {% endfor %}

--- a/oioioi/base/templates/nesting/admin/inlines/tabular.html
+++ b/oioioi/base/templates/nesting/admin/inlines/tabular.html
@@ -27,7 +27,7 @@
               {% for field in inline_admin_formset.fields %}
                   {% if not field.widget.is_hidden %}
                       <th class="djn-th {{ field.label|lower|slugify }}{% if field.required %} required{% endif %}">{{ field.label|capfirst }}
-                      {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
+                      {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" data-toggle="tooltip" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
                       </th>
                   {% endif %}
               {% endfor %}

--- a/oioioi/teachers/templates/teachers/members.html
+++ b/oioioi/teachers/templates/teachers/members.html
@@ -50,7 +50,7 @@
                 <h2 class="method-title">
                     {% trans "Groups" %}
                     <span class="d-inline-block" tabIndex="0" data-toggle="tooltip" title='{% trans "Groups enable adding and removing many pupils at once. In the list below you can find all groups added to this contest and manage them. All pupils in the groups below have access to this contest." %}'>
-                         <button class="disabled btn btn-link help-tooltip">
+                         <button class="disabled btn btn-link help-tooltip" data-toggle="tooltip">
                             <sup>
                                 <i class="fa-solid fa-circle-question"></i>
                             </sup>
@@ -135,7 +135,7 @@
                 <h2 class="method-title" id="members-view">
                     {% trans "Members" %}
                     <span class="d-inline-block" tabIndex="0" data-toggle="tooltip" data-toggle="tooltip" title='{% trans "This section enables you to add pupils to contest in the old fashioned way, by sharing access link. You can also create new user group from members below, which will be automatically added to this contest." %}'>
-                        <button class="disabled btn btn-link help-tooltip">
+                        <button class="disabled btn btn-link help-tooltip" data-toggle="tooltip">
                             <sup>
                                 <i class="fa-solid fa-circle-question"></i>
                             </sup>


### PR DESCRIPTION
Solves issue #659.
The Reveal limit help text was shown through the browser’s native tooltip in the inline admin, which delays display on hover. Adding Bootstrap tooltip behavior makes it appear immediately.