### PR TITLE
Remove deprecated utcnow usage

### DIFF
--- a/oioioi/ipdnsauth/management/commands/ipauth-dnsserver.py
+++ b/oioioi/ipdnsauth/management/commands/ipauth-dnsserver.py
@@ -87,7 +87,7 @@ class BaseRequestHandler(socketserver.BaseRequestHandler):
         return reply.pack()
 
     def handle(self):
-        now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
+        now = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
         logger.debug(
             "%s request %s (%s %s):",
             self.__class__.__name__[:3],

--- a/oioioi/ipdnsauth/management/commands/ipauth-dnsserver.py
+++ b/oioioi/ipdnsauth/management/commands/ipauth-dnsserver.py
@@ -87,7 +87,7 @@ class BaseRequestHandler(socketserver.BaseRequestHandler):
         return reply.pack()
 
     def handle(self):
-        now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
+        now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
         logger.debug(
             "%s request %s (%s %s):",
             self.__class__.__name__[:3],


### PR DESCRIPTION
Replaces `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.UTC)`

Closes #652 