### PR TITLE
Fix: Reuploading a task package of a different type than the existing task

### DIFF
--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -15,7 +15,8 @@ def display_reacted_by(context, post, rtype):
 
     request = context.get('request')
     if request and hasattr(request, 'contest'):
-        get_name = lambda user: request.contest.controller.get_user_public_name(request, user)
+        def get_name(user):
+            return request.contest.controller.get_user_public_name(request, user)
     else:
         get_name = get_user_display_name
 

--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -13,8 +13,9 @@ def display_reacted_by(context, post, rtype):
     if rtype not in POST_REACTION_TO_PREFETCH_ATTR:
         raise ValueError("Invalid reaction type in template:" + rtype)
 
-    request = context.get('request')
-    if request and hasattr(request, 'contest'):
+    request = context.get("request")
+    if request and hasattr(request, "contest"):
+        
         def get_name(user):
             return request.contest.controller.get_user_public_name(request, user)
     else:

--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -15,7 +15,7 @@ def display_reacted_by(context, post, rtype):
 
     request = context.get("request")
     if request and hasattr(request, "contest"):
-        
+
         def get_name(user):
             return request.contest.controller.get_user_public_name(request, user)
     else:

--- a/oioioi/forum/templatetags/display_reacted_by.py
+++ b/oioioi/forum/templatetags/display_reacted_by.py
@@ -8,12 +8,18 @@ from oioioi.forum.models import POST_REACTION_TO_COUNT_ATTR, POST_REACTION_TO_PR
 register = template.Library()
 
 
-@register.simple_tag
-def display_reacted_by(post, rtype):
+@register.simple_tag(takes_context=True)
+def display_reacted_by(context, post, rtype):
     if rtype not in POST_REACTION_TO_PREFETCH_ATTR:
         raise ValueError("Invalid reaction type in template:" + rtype)
 
-    output = ", ".join([get_user_display_name(reaction.author) for reaction in getattr(post, POST_REACTION_TO_PREFETCH_ATTR[rtype])])
+    request = context.get('request')
+    if request and hasattr(request, 'contest'):
+        get_name = lambda user: request.contest.controller.get_user_public_name(request, user)
+    else:
+        get_name = get_user_display_name
+
+    output = ", ".join([get_name(reaction.author) for reaction in getattr(post, POST_REACTION_TO_PREFETCH_ATTR[rtype])])
 
     count = getattr(post, POST_REACTION_TO_COUNT_ATTR[rtype])
     max_count = getattr(settings, "FORUM_REACTIONS_TO_DISPLAY", 10)

--- a/oioioi/quizzes/controllers.py
+++ b/oioioi/quizzes/controllers.py
@@ -38,6 +38,7 @@ ContestController.mix_in(QuizContestControllerMixin)
 
 class QuizProblemController(ProblemController):
     """Defines rules for quizzes."""
+
     description = _("Quiz problem")
 
     def adjust_problem(self):

--- a/oioioi/quizzes/controllers.py
+++ b/oioioi/quizzes/controllers.py
@@ -38,6 +38,7 @@ ContestController.mix_in(QuizContestControllerMixin)
 
 class QuizProblemController(ProblemController):
     """Defines rules for quizzes."""
+    description = _("Quiz problem")
 
     def adjust_problem(self):
         """Called whan a (usually new) problem has just got the controller

--- a/oioioi/sinolpack/package.py
+++ b/oioioi/sinolpack/package.py
@@ -16,6 +16,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.core.validators import slug_re
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
 
 from oioioi.base.utils import generate_key, naturalsort_key
@@ -318,10 +319,13 @@ class SinolPackage:
         self._create_problem_or_reuse_if_exists(self.package.problem)
         return self._extract_and_process_package()
 
+    @_describe_processing_error
     def _create_problem_or_reuse_if_exists(self, existing_problem):
+        """Creating or reusing Problem instance."""
         if existing_problem:
             self.problem = existing_problem
             self._ensure_short_name_equality_with(existing_problem)
+            self._ensure_compatible_controller(existing_problem)
         else:
             self.problem = self._create_problem_instance()
             problem_site = ProblemSite(problem=self.problem, url_key=generate_key())
@@ -332,11 +336,39 @@ class SinolPackage:
         self.problem.package_backend_name = self.package_backend_name
         self.problem.save()
 
+    @_describe_processing_error
     def _ensure_short_name_equality_with(self, existing_problem):
+        """Checking if short name didn't change."""
         if existing_problem.short_name != self.short_name:
             raise ProblemPackageError(
-                _("Tried to replace problem '%(oldname)s' with '%(newname)s'. For safety, changing problem short name is not possible.")
+                _(
+                    "Tried to replace problem '%(oldname)s' with '%(newname)s'. "
+                    "For safety, changing problem short name is not possible."
+                )
                 % {"oldname": existing_problem.short_name, "newname": self.short_name}
+            )
+
+    @_describe_processing_error
+    def _ensure_compatible_controller(self, existing_problem):
+        """Checking if task type didn't change."""
+        new_controller_name = self._get_controller_name()
+        if existing_problem.controller_name != new_controller_name:
+            try:
+                old_controller_desc = existing_problem.controller.description
+            except Exception:
+                old_controller_desc = existing_problem.controller_name
+
+            try:
+                new_controller_desc = import_string(new_controller_name).description
+            except Exception:
+                new_controller_desc = new_controller_name
+
+            raise ProblemPackageError(
+                _(
+                    "The task type of the reuploaded package doesn't match "
+                    "the existing task type (%(old)s vs %(new)s)."
+                )
+                % {"old": old_controller_desc, "new": new_controller_desc}
             )
 
     def _create_problem_instance(self):

--- a/oioioi/sinolpack/package.py
+++ b/oioioi/sinolpack/package.py
@@ -341,10 +341,7 @@ class SinolPackage:
         """Checking if short name didn't change."""
         if existing_problem.short_name != self.short_name:
             raise ProblemPackageError(
-                _(
-                    "Tried to replace problem '%(oldname)s' with '%(newname)s'. "
-                    "For safety, changing problem short name is not possible."
-                )
+                _("Tried to replace problem '%(oldname)s' with '%(newname)s'. For safety, changing problem short name is not possible.")
                 % {"oldname": existing_problem.short_name, "newname": self.short_name}
             )
 
@@ -364,10 +361,7 @@ class SinolPackage:
                 new_controller_desc = new_controller_name
 
             raise ProblemPackageError(
-                _(
-                    "The task type of the reuploaded package doesn't match "
-                    "the existing task type (%(old)s vs %(new)s)."
-                )
+                _("The task type of the reuploaded package doesn't match the existing task type (%(old)s vs %(new)s).")
                 % {"old": old_controller_desc, "new": new_controller_desc}
             )
 


### PR DESCRIPTION
Fix regarding this bug: https://github.com/sio2project/oioioi/issues/683

1. Added Task Type Validation: In oioioi/sinolpack/package.py, when reuploading to an existing_problem, the system now calls _ensure_compatible_controller. This method compares the existing problem's controller with the new package's determined controller. If they do not match, it blocks the reupload by raising a ProblemPackageError.

2. Improved Error Reporting:_create_problem_or_reuse_if_exists, _ensure_short_name_equality_with, and the new _ensure_compatible_controller with @_describe_processing_error. This ensures that if the task types mismatch these changes effectively close the gaps allowing interactive packages to overwrite non-interactive tasks and normal packages to overwrite quiz tasks, ensuring task integrity during reuploads.
