### PR TITLE
Add option of searching tags by their abbreviated name

### DIFF
--- a/oioioi/problems/tests/test_tags.py
+++ b/oioioi/problems/tests/test_tags.py
@@ -1,9 +1,11 @@
+import json
 import urllib.parse
 
 from django.test.utils import override_settings
 from django.urls import reverse
 
 from oioioi.base.tests import TestCase
+from oioioi.problems.models import OriginTagLocalization
 from oioioi.problems.tests.utilities import AssertContainsOnlyMixin
 
 
@@ -140,6 +142,15 @@ class TestProblemSearchHintsTags(TestCase, AssertContainsOnlyMixin):
     def get_query_url(self, parameters):
         return self.url + "?" + urllib.parse.urlencode(parameters)
 
+    def get_hints(self, query):
+        response = self.client.get(self.get_query_url({"q": query}))
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.content)
+
+    @staticmethod
+    def match_hints(hints, **kwargs):
+        return [hint for hint in hints if all(hint.get(key) == value for key, value in kwargs.items())]
+
     @override_settings(LANGUAGE_CODE="en", PROBLEM_TAGS_VISIBLE=False)
     def test_search_no_hints_tags_basic(self):
         self.client.get("/c/c/")
@@ -198,11 +209,44 @@ class TestProblemSearchHintsTags(TestCase, AssertContainsOnlyMixin):
 
         response = self.client.get(self.get_query_url({"q": "dp"}))
         self.assertEqual(response.status_code, 200)
-        self.assert_contains_only(response, [])
+        self.assert_contains_only(response, ["dp"])
+
+        response = self.client.get(self.get_query_url({"q": "lcis"}))
+        self.assertEqual(response.status_code, 200)
+        self.assert_contains_only(response, ["lcis"])
 
         response = self.client.get(self.get_query_url({"q": "increasing"}))
         self.assertEqual(response.status_code, 200)
         self.assert_contains_only(response, ["lcis"])
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_search_hints_tags_by_canonical_names(self):
+        self.client.get("/c/c/")
+
+        hints = self.get_hints("dp")
+        algorithm_hints = self.match_hints(hints, prefix="algorithm", value="dp")
+        self.assertEqual(len(algorithm_hints), 1)
+        self.assertEqual(algorithm_hints[0]["name"], "Dynamic programming")
+
+        hints = self.get_hints("very-hard")
+        difficulty_hints = self.match_hints(hints, prefix="difficulty", value="very-hard")
+        self.assertEqual(len(difficulty_hints), 1)
+        self.assertEqual(difficulty_hints[0]["name"], "Very hard")
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_search_hints_origintag_by_canonical_name_and_abbreviation(self):
+        self.client.get("/c/c/")
+
+        hints = self.get_hints("pa")
+        origin_hints = self.match_hints(hints, prefix="origin", value="pa")
+        self.assertEqual(len(origin_hints), 1)
+        self.assertEqual(origin_hints[0]["name"], "Potyczki Algorytmiczne")
+
+        OriginTagLocalization.objects.filter(origin_tag__name="pa", language="en").update(short_name="pa-short")
+        hints = self.get_hints("pa-short")
+        origin_hints = self.match_hints(hints, prefix="origin", value="pa")
+        self.assertEqual(len(origin_hints), 1)
+        self.assertEqual(origin_hints[0]["name"], "Potyczki Algorytmiczne")
 
     @override_settings(LANGUAGE_CODE="en", PROBLEM_TAGS_VISIBLE=False)
     def test_search_no_hints_origininfo(self):

--- a/oioioi/problems/views.py
+++ b/oioioi/problems/views.py
@@ -1008,7 +1008,9 @@ def get_selected_origintag_hints_view(request):
 
 
 def get_nonselected_origintag_hints(query):
-    return _get_origintag_hints(OriginTagLocalization.objects.filter(full_name__icontains=query))
+    return _get_origintag_hints(
+        OriginTagLocalization.objects.filter(Q(full_name__icontains=query) | Q(short_name__icontains=query) | Q(origin_tag__name__icontains=query))
+    )
 
 
 @uniquefy("name")
@@ -1022,7 +1024,7 @@ def get_algorithm_and_difficulty_tag_hints(query):
                 "prefix": "algorithm",
                 "value": atl.algorithm_tag.name,
             }
-            for atl in AlgorithmTagLocalization.objects.filter(full_name__icontains=query)
+            for atl in AlgorithmTagLocalization.objects.filter(Q(full_name__icontains=query) | Q(algorithm_tag__name__icontains=query))
         ]
     )
     result.extend(
@@ -1034,7 +1036,7 @@ def get_algorithm_and_difficulty_tag_hints(query):
                 "prefix": "difficulty",
                 "value": dtl.difficulty_tag.name,
             }
-            for dtl in DifficultyTagLocalization.objects.filter(full_name__icontains=query)
+            for dtl in DifficultyTagLocalization.objects.filter(Q(full_name__icontains=query) | Q(difficulty_tag__name__icontains=query))
         ]
     )
 


### PR DESCRIPTION
Solves #681. Adds option to search tag by their commonly used (short) name.

<img width="1166" height="291" alt="tag-improvement" src="https://github.com/user-attachments/assets/dd79410e-d3de-4fd7-8bd1-07594ccc661b" />
