### PR TITLE
Add evaluation scheduling option to rejudging

### DIFF
--- a/oioioi/contests/controllers.py
+++ b/oioioi/contests/controllers.py
@@ -717,8 +717,8 @@ class ContestController(RegisteredSubclassesBase, ObjectWithMixins):
         problem = problem_instance.problem
         return problem.controller.create_submission(request, problem_instance, form_data, **kwargs)
 
-    def judge(self, submission, extra_args=None, is_rejudge=False):
-        submission.problem_instance.problem.controller.judge(submission, extra_args, is_rejudge)
+    def judge(self, submission, extra_args=None, is_rejudge=False, delay: int | float = 0):
+        submission.problem_instance.problem.controller.judge(submission, extra_args, is_rejudge, delay)
 
     def fill_evaluation_environ(self, environ, submission):
         submission.problem_instance.problem.controller.fill_evaluation_environ(environ, submission)

--- a/oioioi/contests/templates/contests/confirm_rejudge.html
+++ b/oioioi/contests/templates/contests/confirm_rejudge.html
@@ -14,9 +14,8 @@
 {% endblock %}
 
 {% block confirmation_form %}
-    <p>{% trans "Are you sure?" %}</p>
-
-    <form method="get" class="mb-3">
+    <form method="post">
+        {% csrf_token %}
         <div class="row mb-2">
             <label class="col-sm-3 col-form-label" for="date_from">{% trans "From date" %}</label>
             <div class="col-sm-9">
@@ -40,21 +39,16 @@
                 </div>
             </div>
         </div>
-        <button type="submit" class="btn btn-secondary">
-            {% trans "Preview count" %}
-        </button>
-    </form>
+        <div class="form-group mb-3">
+            <button type="submit" formmethod="get" class="btn btn-secondary">
+                {% trans "Preview count" %}
+            </button>
+        </div>
 
-    <form method="post">
-        {% csrf_token %}
-        <input type="hidden" name="post" value="yes"/>
-        <input type="hidden" name="date_from" value="{{ date_from }}"/>
-        <input type="hidden" name="date_to" value="{{ date_to }}"/>
-        {% if last_only %}
-        <input type="hidden" name="last_only" value="on"/>
-        {% endif %}
+        <p>{% trans "Are you sure?" %}</p>
+
         <div class="form-group">
-            <button type="submit" class="btn btn-danger">
+            <button type="submit" name="post" value="yes" class="btn btn-danger">
                 {% trans "Yes, I am sure." %}
             </button>
             <button type="button" class="btn btn-outline-secondary" onclick="history.back()">

--- a/oioioi/contests/templates/contests/confirm_rejudge.html
+++ b/oioioi/contests/templates/contests/confirm_rejudge.html
@@ -44,7 +44,130 @@
                 {% trans "Preview count" %}
             </button>
         </div>
+<style>
+    /* Ensure the native radio dots are actually hidden */
+    .btn-check {
+        position: absolute;
+        clip: rect(0, 0, 0, 0);
+        pointer-events: none;
+    }
 
+    /* Style for the group to look like a single segmented bar */
+    .segmented-control .btn {
+        border-radius: 0;
+        border-color: #dee2e6;
+        color: #6c757d;
+        background-color: #fff;
+        padding: 0.5rem 1rem;
+        transition: all 0.2s ease;
+    }
+
+    .segmented-control .btn:first-of-type {
+        border-top-left-radius: 0.375rem;
+        border-bottom-left-radius: 0.375rem;
+    }
+
+    .segmented-control .btn:last-of-type {
+        border-top-right-radius: 0.375rem;
+        border-bottom-right-radius: 0.375rem;
+    }
+
+    /* Active State Style */
+    .btn-check:checked + .btn {
+        background-color: #0d6efd; /* primary color */
+        border-color: #0d6efd;
+        color: white;
+        z-index: 2; /* Keeps the border on top */
+    }
+
+    .btn:hover {
+        background-color: #f8f9fa;
+    }
+    
+    /* Custom scheduling inputs visibility */
+    #custom-scheduling-inputs {
+        display: none;
+    }
+</style>
+
+<div class="row mb-3 align-items-center">
+    <label class="col-sm-3 col-form-label fw-bold">{% trans "Evaluation scheduling" %}</label>
+    <div class="col-sm-9">
+        <div class="btn-group segmented-control w-100" role="group">
+            <input type="radio" class="btn-check" name="evaluation_scheduling" id="instant" value="instant" checked>
+            <label class="btn" for="instant">{% trans "Instant" %}</label>
+
+            <input type="radio" class="btn-check" name="evaluation_scheduling" id="delayed" value="delayed">
+            <label class="btn" for="delayed">{% trans "Delayed" %}</label>
+
+            <input type="radio" class="btn-check" name="evaluation_scheduling" id="slow" value="slow">
+            <label class="btn" for="slow">{% trans "Slow" %}</label>
+
+            <input type="radio" class="btn-check" name="evaluation_scheduling" id="custom" value="custom">
+            <label class="btn" for="custom">{% trans "Custom" %}</label>
+        </div>
+    </div>
+</div>
+
+<div id="custom-scheduling-inputs" class="row mb-3 align-items-center">
+    <label class="col-sm-3 col-form-label fw-bold">{% trans "Schedule" %}</label>
+    <div class="col-sm-9">
+        <div class="input-group">
+            <input type="number" id="custom_batch_size" name="custom_batch_size" 
+                   class="form-control" style="max-width: 100px;" min="1" placeholder="1">
+            <span class="input-group-text">{% trans "submission(-s) every" %}</span>
+            <input type="number" id="custom_delay_step" name="custom_delay_step" 
+                   class="form-control" style="max-width: 100px;" min="1" placeholder="30">
+            <span class="input-group-text">{% trans "seconds" %}</span>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.querySelectorAll('input[name="evaluation_scheduling"]').forEach(radio => {
+        radio.addEventListener('change', function() {
+            const customInputs = document.getElementById('custom-scheduling-inputs');
+            const batchSizeInput = document.getElementById('custom_batch_size');
+            const delayStepInput = document.getElementById('custom_delay_step');
+            
+            if (this.value === 'custom') {
+                customInputs.style.display = 'flex';
+                batchSizeInput.disabled = false;
+                delayStepInput.disabled = false;
+                batchSizeInput.required = true;
+                delayStepInput.required = true;
+            } else {
+                customInputs.style.display = 'none';
+                batchSizeInput.disabled = true;
+                delayStepInput.disabled = true;
+                batchSizeInput.required = false;
+                delayStepInput.required = false;
+            }
+        });
+    });
+    
+    // Initialize on page load
+    const batchSizeInput = document.getElementById('custom_batch_size');
+    const delayStepInput = document.getElementById('custom_delay_step');
+    
+    if (batchSizeInput && delayStepInput) {
+        // Set default values if empty
+        if (!batchSizeInput.value) batchSizeInput.value = '1';
+        if (!delayStepInput.value) delayStepInput.value = '30';
+        
+        // Check if custom is already selected on page load
+        if (document.getElementById('custom').checked) {
+            document.getElementById('custom-scheduling-inputs').style.display = 'flex';
+            batchSizeInput.disabled = false;
+            delayStepInput.disabled = false;
+            batchSizeInput.required = true;
+            delayStepInput.required = true;
+        } else {
+            batchSizeInput.disabled = true;
+            delayStepInput.disabled = true;
+        }
+    }
+</script>
         <p>{% trans "Are you sure?" %}</p>
 
         <div class="form-group">

--- a/oioioi/contests/views.py
+++ b/oioioi/contests/views.py
@@ -745,8 +745,13 @@ def rejudge_all_submissions_for_problem_view(request, problem_instance_id):
     selected_count = submissions.count()
 
     if request.POST:
-        for submission in submissions:
-            problem_instance.controller.judge(submission, {}, is_rejudge=True)
+        # batch_size, delay_step = 6, 30
+        batch_size, delay_step = 1, 0.5
+        n_batches = -(selected_count // -batch_size)
+        for i in range(n_batches):
+            batch, delay = submissions[i*batch_size:(i+1)*batch_size], delay_step*i
+            for submission in batch:
+                problem_instance.controller.judge(submission, {}, is_rejudge=True, delay=delay)
         messages.info(
             request,
             ngettext_lazy(

--- a/oioioi/contests/views.py
+++ b/oioioi/contests/views.py
@@ -723,6 +723,26 @@ def user_info_redirect_view(request):
         reverse("user_info", kwargs={"contest_id": request.contest.id, "user_id": user.id}),
     )
 
+def extract_scheduling_vars_from_params(params, submission_count):
+    form_string = params.get("evaluation_scheduling", "instant")
+
+    match form_string:
+        case "instant":
+            return submission_count, 0
+        case "delayed":
+            ten_minutes = 10 * 60
+            return 1, ten_minutes/submission_count
+        case "slow":
+            one_hour = 60 * 60
+            return 1, one_hour/submission_count
+        case "custom":
+            custom_batch_size = int(params.get("custom_batch_size", None))
+            custom_delay_step = int(params.get("custom_delay_step", None))
+            if custom_batch_size <= 0 or custom_delay_step < 0:
+                raise ValueError("Custom batch size must be positive and delay step must be non-negative.")
+            return custom_batch_size, custom_delay_step
+        case _:
+            raise SuspiciousOperation("Invalid evaluation scheduling option")
 
 @enforce_condition(contest_exists & is_contest_basicadmin)
 def rejudge_all_submissions_for_problem_view(request, problem_instance_id):
@@ -733,6 +753,8 @@ def rejudge_all_submissions_for_problem_view(request, problem_instance_id):
     date_from = params.get("date_from", "").strip()
     date_to = params.get("date_to", "").strip()
     last_only = params.get("last_only") == "on"
+    evaluation_scheduling = params.get("evaluation_scheduling", "instant")
+    print(f"DEBUG: Evaluation scheduling selected: {evaluation_scheduling}")
 
     submissions = problem_instance.submission_set.all()
     total_count = submissions.count()
@@ -745,8 +767,7 @@ def rejudge_all_submissions_for_problem_view(request, problem_instance_id):
     selected_count = submissions.count()
 
     if request.POST:
-        # batch_size, delay_step = 6, 30
-        batch_size, delay_step = 1, 0.5
+        batch_size, delay_step = extract_scheduling_vars_from_params(params, selected_count)
         n_batches = -(selected_count // -batch_size)
         for i in range(n_batches):
             batch, delay = submissions[i*batch_size:(i+1)*batch_size], delay_step*i
@@ -767,10 +788,14 @@ def rejudge_all_submissions_for_problem_view(request, problem_instance_id):
             problem_instance.save(update_fields=["needs_rejudge"])
         return safe_redirect(request, reverse("oioioiadmin:contests_probleminstance_changelist"))
 
+    # TODO: clear this up, in a non-draft PR
+    custom_batch_size = params.get("custom_batch_size", "1")
+    custom_delay_step = params.get("custom_delay_step", "0")
+
     return TemplateResponse(
         request,
         "contests/confirm_rejudge.html",
-        {"count": selected_count, "date_from": date_from, "date_to": date_to, "last_only": last_only},
+        {"count": selected_count, "date_from": date_from, "date_to": date_to, "last_only": last_only, "evaluation_scheduling": evaluation_scheduling, "custom_batch_size": custom_batch_size, "custom_delay_step": custom_delay_step},
     )
 
 

--- a/oioioi/problems/controllers.py
+++ b/oioioi/problems/controllers.py
@@ -137,7 +137,7 @@ class ProblemController(RegisteredSubclassesBase, ObjectWithMixins):
         """
         pass
 
-    def judge(self, submission, extra_args=None, is_rejudge=False):
+    def judge(self, submission, extra_args=None, is_rejudge=False, delay: int | float = 0):
         environ = create_environ()
         environ["extra_args"] = extra_args or {}
         environ["is_rejudge"] = is_rejudge
@@ -222,6 +222,8 @@ class ProblemController(RegisteredSubclassesBase, ObjectWithMixins):
         )
 
         evalmgr_extra_args = environ.get("evalmgr_extra_args", {})
+        if delay > 0:
+            evalmgr_extra_args["countdown"] = delay
         logger.debug(
             "Judging submission #%d with environ:\n %s",
             submission.id,


### PR DESCRIPTION
This PR addresses https://github.com/sio2project/oioioi/issues/672, by providing the admin with an option to control evaluation queue scheduling. The backend was relatively simple, as celery jobs support a countdown argument, which delays the job's execution by the provided number of seconds.

In the current setup, the admin would have the following scheduling options:
1) Instant (default) - each submission is judged ASAP
2) Delayed - the submissions are spread out evenly across 10 minutes
3) Slow - the submissions are spread out evenly across 1 hour
4) Custom - the admin can define the quantity and cadence with which the submissions are queued.
<img width="1246" height="534" alt="image" src="https://github.com/user-attachments/assets/006136b5-b8ce-43a6-8d25-0cea35232f84" />

Before switching this PR from a draft, I wish to:
1) Clear up what "delayed" and "slow" mean - currently the durations are hard coded in a random place in the code. There should be an info button, which informs the user, what those are.
2) Clean up code
3) Add test coverage

I seek feedback on:
1) The modifications of the "judge" methods - the "delay" parameter defaults to 0, and is only passed if it is over 0, so this shouldn't affect any call sites. However, these are crucial parts of the infrastructure, and should be reviewed thoroughly.
2) The "delayed" and "solved" durations - are 10 minutes and 1 hour sensible?
3) The overall design