### PR TITLE
Not working instructions for running cypress tests

### DIFF
--- a/oioioi/oi/migrations/0010_drop_legacy_region_tables.py
+++ b/oioioi/oi/migrations/0010_drop_legacy_region_tables.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("oi", "0009_sync_indexes_state"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                "DROP TABLE IF EXISTS oi_oionsiteregistration CASCADE",
+                "DROP TABLE IF EXISTS oi_region CASCADE",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/oioioi/oi/migrations/0010_drop_legacy_region_tables.py
+++ b/oioioi/oi/migrations/0010_drop_legacy_region_tables.py
@@ -10,8 +10,8 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             sql=[
-                "DROP TABLE IF EXISTS oi_oionsiteregistration CASCADE",
-                "DROP TABLE IF EXISTS oi_region CASCADE",
+                "DROP TABLE IF EXISTS oi_oionsiteregistration",
+                "DROP TABLE IF EXISTS oi_region",
             ],
             reverse_sql=migrations.RunSQL.noop,
         ),


### PR DESCRIPTION
After Region model was moved to participants, some tables were left behind. This migration fixes this and now ./easy_toolbox flush-db works. Solves issue #568.