### PR TITLE
Added default timezone Europe/Warsaw

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,6 +2,7 @@ x-common-envs: &common-envs
  FILETRACKER_URL: 'http://s3dedup:9999/ft'
  DATABASE_HOST: 'db'
  DATABASE_PORT: '5432'
+ OIOIOI_TIMEZONE: '${OIOIOI_TIMEZONE:-Europe/Warsaw}'
 
 services:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ x-common-envs: &common-envs
  FILETRACKER_URL: 'http://web:9999'
  DATABASE_HOST: 'db'
  DATABASE_PORT: '5432'
+ OIOIOI_TIMEZONE: '${OIOIOI_TIMEZONE:-Europe/Warsaw}'
 
 services:
   db:


### PR DESCRIPTION
Set the default value of `OIOIOI_TIMEZONE` to `Europe/Warsaw` in both `docker-compose.yml` and `docker-compose-dev.yml`.

Closes #698 