### PR TITLE
 Enforce pnpm@9 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && \
         npm && \
     apt-get clean && \
     rm -rf /usr/share/doc/texlive* && \
-    npm install -g pnpm
+    npm install -g pnpm@9
 
 # This is oioioi user linux uid. Setting it is useful in development.
 # By default we use an unused uid of 1234.


### PR DESCRIPTION
Docker build failed: https://github.com/sio2project/oioioi/actions/runs/26171675408/job/76990809024

We need to pin pnpm to version 9.