### PR TITLE
Visible contests cleanup

### DIFF
--- a/oioioi/contests/utils.py
+++ b/oioioi/contests/utils.py
@@ -400,16 +400,6 @@ def used_controllers():
 
 def visible_contests_as_django_queryset(request):
     """Returns query set of contests visible to the logged in user."""
-    if request.GET.get("living", "safely") == "dangerously":
-        visible_query = Contest.objects.none()
-        for controller_name in used_controllers():
-            controller_class = import_string(controller_name)
-            # HACK: we pass None contest just to call visible_contests_query.
-            # This is a workaround for mixins not taking classmethods very well.
-            controller = controller_class(None)
-            subquery = Contest.objects.filter(controller_name=controller_name).filter(controller.registration_controller().visible_contests_query(request))
-            visible_query = visible_query.union(subquery, all=False)
-        return visible_query
     visible_query = Q_always_false()
     for controller_name in used_controllers():
         controller_class = import_string(controller_name)

--- a/oioioi/contests/utils.py
+++ b/oioioi/contests/utils.py
@@ -398,51 +398,6 @@ def used_controllers():
     return Contest.objects.values_list("controller_name", flat=True).distinct()
 
 
-@request_cached
-def visible_contests_queryset_old(request):
-    """Returns Q for filtering contests visible to the logged in user."""
-    if request.GET.get("living", "safely") == "dangerously":
-        visible_query = Contest.objects.none()
-        for controller_name in used_controllers():
-            controller_class = import_string(controller_name)
-            # HACK: we pass None contest just to call visible_contests_query.
-            # This is a workaround for mixins not taking classmethods very well.
-            controller = controller_class(None)
-            subquery = Contest.objects.filter(controller_name=controller_name).filter(controller.registration_controller().visible_contests_query(request))
-            visible_query = visible_query.union(subquery, all=False)
-        return visible_query
-    visible_query = Q_always_false()
-    for controller_name in used_controllers():
-        controller_class = import_string(controller_name)
-        # HACK: we pass None contest just to call visible_contests_query.
-        # This is a workaround for mixins not taking classmethods very well.
-        controller = controller_class(None)
-        visible_query |= Q(controller_name=controller_name) & controller.registration_controller().visible_contests_query(request)
-    return visible_query
-
-
-def visible_contests_query(request):
-    """Returns materialized set of contests visible to the logged in user."""
-    if request.GET.get("living", "safely") == "dangerously":
-        visible_query = Contest.objects.none()
-        for controller_name in used_controllers():
-            controller_class = import_string(controller_name)
-            # HACK: we pass None contest just to call visible_contests_query.
-            # This is a workaround for mixins not taking classmethods very well.
-            controller = controller_class(None)
-            subquery = Contest.objects.filter(controller_name=controller_name).filter(controller.registration_controller().visible_contests_query(request))
-            visible_query = visible_query.union(subquery, all=False)
-        return visible_query
-    visible_query = Q_always_false()
-    for controller_name in used_controllers():
-        controller_class = import_string(controller_name)
-        # HACK: we pass None contest just to call visible_contests_query.
-        # This is a workaround for mixins not taking classmethods very well.
-        controller = controller_class(None)
-        visible_query |= Q(controller_name=controller_name) & controller.registration_controller().visible_contests_query(request)
-    return Contest.objects.filter(visible_query).distinct()
-
-
 def visible_contests_as_django_queryset(request):
     """Returns query set of contests visible to the logged in user."""
     if request.GET.get("living", "safely") == "dangerously":
@@ -472,20 +427,16 @@ def visible_contests(request):
 
 
 @request_cached_complex
-def visible_contests_queryset(request, filter_value=None):
-    contests = visible_contests_as_django_queryset(request)
-    if filter_value is not None:
-        contests = contests.filter(Q(name__icontains=filter_value) | Q(id__icontains=filter_value) | Q(school_year=filter_value))
-    return set(contests)
-
-
-@request_cached_complex
 def visible_filtered_contests_as_django_queryset(request, filter_value=None):
-    """TODO: remove code duplication visible_contests_queryset/visible_contests_query"""
     contests = visible_contests_as_django_queryset(request)
     if filter_value is not None:
         contests = contests.filter(Q(name__icontains=filter_value) | Q(id__icontains=filter_value) | Q(school_year=filter_value))
     return contests
+
+
+@request_cached_complex
+def visible_filtered_contests(request, filter_value=None):
+    return set(visible_filtered_contests_as_django_queryset(request, filter_value))
 
 
 # why is there no `can_admin_contest_query`?

--- a/oioioi/contests/views.py
+++ b/oioioi/contests/views.py
@@ -70,7 +70,7 @@ from oioioi.contests.utils import (
     is_contest_observer,
     stringify_problems_limits,
     visible_contests,
-    visible_contests_queryset,
+    visible_filtered_contests,
     visible_filtered_contests_as_django_queryset,
     visible_problem_instances,
     visible_rounds,
@@ -1240,7 +1240,7 @@ def unarchive_contest(request):
 
 
 def filter_contests_view(request, filter_value=""):
-    contests = set(visible_contests_queryset(request, filter_value))
+    contests = visible_filtered_contests(request, filter_value)
     contests = sorted(contests, key=lambda x: x.creation_date, reverse=True)
 
     context = {

--- a/oioioi/szkopul/views.py
+++ b/oioioi/szkopul/views.py
@@ -5,9 +5,9 @@ from django.utils.translation import gettext_lazy as _
 from oioioi.base.main_page import register_main_page_view
 from oioioi.base.navbar_links import navbar_links_registry
 from oioioi.contests.controllers import submission_template_context
-from oioioi.contests.models import Contest, Submission
+from oioioi.contests.models import Submission
 from oioioi.contests.processors import recent_contests
-from oioioi.contests.utils import visible_contests_queryset_old
+from oioioi.contests.utils import visible_contests
 from oioioi.problems.utils import filter_my_all_visible_submissions
 
 navbar_links_registry.register(
@@ -29,10 +29,9 @@ navbar_links_registry.register(
 def main_page_view(request):
     to_show = getattr(settings, "NUM_RECENT_CONTESTS", 7)
     rcontests = recent_contests(request)
-    # this is unsalvageable
-    contests = list(set(Contest.objects.filter(visible_contests_queryset_old(request)).distinct()[:to_show]).difference(rcontests))
+    contests = list(visible_contests(request).difference(rcontests))
     contests.sort(key=lambda x: x.creation_date, reverse=True)
-    contests = (rcontests + contests)[:to_show]
+    contests = (rcontests + contests[:to_show])[:to_show]
 
     submissions = []
     show_scores = False


### PR DESCRIPTION
The logic for generating the query for visible contests was duplicated across **3** functions.

This PR cleans that up, also removing some old hotfix/perf test (`?living=dangerously` :question:) from prod, as it seems a bit slower than the normal way after the recent performance optimizations PR #690.

Contrary to a comment from SZKOpul-specific mainpage code, getting the recent contests *was* salvageable :smiley:.