### PR TITLE
Sync pnpm lockfile and add a CI check for it

### DIFF
--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
           version: 9 # Same as in Dockerfile.
           run_install: false

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -1,0 +1,27 @@
+name: Check pnpm lockfile
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-pnpm-lockfile:
+    name: Check pnpm lockfile
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9 # Same as in Dockerfile.
+          run_install: false
+
+      - name: Check whether pnpm-lock.yaml matches package.json
+        run: pnpm install --frozen-lockfile --lockfile-only

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@eonasdan/tempus-dominus':
-        specifier: ^6.10.4
+        specifier: ^6.10.2
         version: 6.10.4(@popperjs/core@2.11.8)
       bootstrap:
         specifier: ^5.3.8
@@ -24,7 +24,7 @@ importers:
         specifier: ^2.0.11
         version: 2.0.11
       darkreader:
-        specifier: ^4.9.120
+        specifier: ^4.9.117
         version: 4.9.120
       highcharts:
         specifier: ^12.6.0
@@ -42,35 +42,35 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5
       marked:
-        specifier: ^15.0.12
+        specifier: ^15.0.7
         version: 15.0.12
       mathjax:
-        specifier: ^4.1.1
+        specifier: ^4.0.0
         version: 4.1.1
       select2:
-        specifier: 4.1.0-rc.0
+        specifier: ^4.1.0-rc.0
         version: 4.1.0-rc.0
     devDependencies:
       '@eslint/js':
-        specifier: ^9.39.4
+        specifier: ^9.23.0
         version: 9.39.4
       concurrently:
-        specifier: ^9.2.1
+        specifier: ^9.1.2
         version: 9.2.1
       copy-webpack-plugin:
         specifier: ^14.0.0
         version: 14.0.0(webpack@5.105.4)
       eslint:
-        specifier: ^9.39.4
+        specifier: ^9.23.0
         version: 9.39.4
       expose-loader:
         specifier: ^5.0.1
         version: 5.0.1(webpack@5.105.4)
       globals:
-        specifier: ^16.5.0
+        specifier: ^16.0.0
         version: 16.5.0
       webpack:
-        specifier: ^5.105.4
+        specifier: ^5.105.0
         version: 5.105.4(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.1
@@ -171,6 +171,7 @@ packages:
     resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-win32-x64-msvc@4.56.0':
     resolution: {integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==}


### PR DESCRIPTION
The pnpm lockfile somehow got out of sync with `package.json`, which caused Docker builds to fail locally and on master branch CI.

A CI check was added to prevent that.
Since it just checks the lockfile and doesn't actually install the packages, it runs about as fast as the ruff check.