### PR TITLE
Fix admin inlines after bootstrap upgrade

### DIFF
--- a/oioioi/base/templates/admin/edit_inline/tabular.html
+++ b/oioioi/base/templates/admin/edit_inline/tabular.html
@@ -33,7 +33,7 @@
             {% if inline_admin_form.form.non_field_errors %}
             <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
             {% endif %}
-            <tr class="row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
+            <tr class="form-row row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
                  id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
             <td class="original">
               {% if inline_admin_form.original or inline_admin_form.show_url %}

--- a/oioioi/base/templates/nesting/admin/inlines/tabular.html
+++ b/oioioi/base/templates/nesting/admin/inlines/tabular.html
@@ -51,7 +51,7 @@
                 </ul>
             </td></tr>
             {% endif %}
-            <tr class="djn-tr row{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}">
+            <tr class="djn-tr row form-row{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}">
 
                 <td class="original{% if inline_admin_formset.opts.sortable_field_name %} is-sortable{% endif %}">
                 {% if inline_admin_form.original or inline_admin_form.show_url %}<p>


### PR DESCRIPTION
This fixes admin inlines not allowing for adding new objets as reported [here](https://github.com/sio2project/oioioi/issues/741#issuecomment-4536834096).
It seems that django's javascript requires the `form-row` CSS class, for example [here](https://github.com/django/django/blob/0a2bc6d88ffd7918ca9bbe039ec2f4ed7dd639c9/django/contrib/admin/static/admin/js/inlines.js#L443-L446).

Perhaps this should be merged into a larger PR with other bootstrap fixes when they appear.

CC @malevitzch.