### PR TITLE
Limit querysets for a simpleui view's forms

### DIFF
--- a/oioioi/simpleui/views.py
+++ b/oioioi/simpleui/views.py
@@ -267,9 +267,9 @@ def problem_settings(request, problem_instance_id):
     ProblemInstanceFormset = modelformset_factory(ProblemInstance, form=ProblemInstanceForm, extra=0)
 
     if request.method == "POST":
-        pi_formset = ProblemInstanceFormset(request.POST, prefix="pif")
+        pi_formset = ProblemInstanceFormset(request.POST, queryset=ProblemInstance.objects.filter(id=pi.id), prefix="pif")
 
-        test_formset = TestFormset(request.POST)
+        test_formset = TestFormset(request.POST, queryset=tests)
         # Bind the clean method, which serves as a time limit and max
         # scores equality validator.
         # http://stackoverflow.com/questions/9646187


### PR DESCRIPTION
Limit querysets for a simpleui view's forms.

Lack of this caused fetching of all objects, which was making POSTs timeout client-side and today triggered OOM-killer on prod.

I already applied this fix on prod.

Editing tests from outside of the admin contest may have been possible too, though that wasn't tested.