### PR TITLE
Add 'uwsgi-tcp' SERVER option

### DIFF
--- a/oioioi/deployment/settings.py.template
+++ b/oioioi/deployment/settings.py.template
@@ -37,7 +37,8 @@ ALLOWED_HOSTS = ['oioioi', '127.0.0.1', 'localhost', 'web']
 
 # The server to be run. Options are:
 # 'django' - django's http server
-# 'uwsgi' - uwsgi daemon
+# 'uwsgi' - uwsgi daemon (uwsgi protocol over a Unix socket)
+# 'uwsgi-tcp' - uwsgi daemon (uwsgi protocol over a TCP socket)
 # 'uwsgi-http' - uwsgi daemon with built-in http server
 # 'none' - nothing will be ran
 # SERVER = 'none'

--- a/oioioi/deployment/supervisord.conf.template
+++ b/oioioi/deployment/supervisord.conf.template
@@ -7,7 +7,7 @@ directory={{ PROJECT_DIR }}
 identifier=oioioi-supervisor
 
 [program:uwsgi]
-command=uwsgi {% if settings.SERVER == 'uwsgi-http' %}--http :8000 --static-map {{ settings.STATIC_URL }}={{ settings.STATIC_ROOT }} {% else %}-s {{ PROJECT_DIR }}/uwsgi.sock {% endif %}--umask=000 {% if settings.UWSGI_USE_GEVENT %}--loop=gevent --async=50 {% endif %}--processes=10 -M --max-requests=5000 --disable-logging --need-app --enable-threads --socket-timeout=30 --wsgi-file={{ PROJECT_DIR }}/wsgi.py
+command=uwsgi {% if settings.SERVER == 'uwsgi-http' %}--http :8000 --static-map {{ settings.STATIC_URL }}={{ settings.STATIC_ROOT }} {% elif settings.SERVER == 'uwsgi-tcp' %}-s :8000 {% else %}-s {{ PROJECT_DIR }}/uwsgi.sock {% endif %}--umask=000 {% if settings.UWSGI_USE_GEVENT %}--loop=gevent --async=50 {% endif %}--processes=10 -M --max-requests=5000 --disable-logging --need-app --enable-threads --socket-timeout=30 --wsgi-file={{ PROJECT_DIR }}/wsgi.py
 stopsignal=INT
 startretries=0
 redirect_stderr=false


### PR DESCRIPTION
If `SERVER` settings.py option is equal to `uwsgi`, uwsgi spawned by supervisor listens on a Unix socket.
In some deployment scenarios it is desirable to make it listen on a TCP socket instead (uwsgi protocol over TCP).
This PR adds this, if `SERVER` is equal to `uwsgi-tcp`, uwsgi will listen on TCP port 8000 on all interfaces (exactly as `uwsgi-http` networking-wise, so I think reasonable choice here).