### PR TITLE
Added spaces between resource usage and unit

### DIFF
--- a/oioioi/programs/templatetags/memoryformat.py
+++ b/oioioi/programs/templatetags/memoryformat.py
@@ -10,6 +10,6 @@ def memoryformat(value):
         return "???"
     mebibytes = value / 1024.0
     if mebibytes < 10:
-        return _("%(mebibytes).1fMiB") % {"mebibytes": mebibytes}
+        return _("%(mebibytes).1f MiB") % {"mebibytes": mebibytes}
     else:
-        return _("%(mebibytes)dMiB") % {"mebibytes": mebibytes}
+        return _("%(mebibytes)d MiB") % {"mebibytes": mebibytes}

--- a/oioioi/programs/templatetags/runtimeformat.py
+++ b/oioioi/programs/templatetags/runtimeformat.py
@@ -10,6 +10,6 @@ def runtimeformat(value):
         return "???"
     seconds = value / 1000.0
     if seconds < 200:
-        return _("%(seconds).2fs") % {"seconds": seconds}
+        return _("%(seconds).2f s") % {"seconds": seconds}
     else:
-        return _("%(minutes)dm %(seconds).2fs") % {"minutes": int(seconds // 60), "seconds": (seconds % 60)}
+        return _("%(minutes)d m %(seconds).2f s") % {"minutes": int(seconds // 60), "seconds": (seconds % 60)}


### PR DESCRIPTION
Applies the fix mentioned in #763 so instead of "42MiB" we get "42 MiB", analogically "1.00s" becomes "1.00 s".

Closes #763.