### PR TITLE
Fixed highcharts crash on the manage workers page

### DIFF
--- a/oioioi/simpleui/templates/simpleui/contest/contest.html
+++ b/oioioi/simpleui/templates/simpleui/contest/contest.html
@@ -12,7 +12,7 @@
 
 {% block scripts %}
     {{ block.super }}
-    <script type="text/javascript" src="{% static 'highcharts/lib/highcharts.js' %}"></script>
+    <script type="text/javascript" src="{% static 'highcharts/highcharts.js' %}"></script>
     <script type="text/javascript" src="{% static 'simpleui/contest/problem.js' %}"></script>
     <script type="text/javascript" src="{% static 'simpleui/contest/contest.js' %}"></script>
     <script type="text/javascript">

--- a/oioioi/simpleui/templates/simpleui/main_dashboard/dashboard.html
+++ b/oioioi/simpleui/templates/simpleui/main_dashboard/dashboard.html
@@ -33,7 +33,7 @@
             {% endblock %}
 	    </nav>
     </header>
-    <script type="text/javascript" src="{% static 'highcharts/lib/highcharts.js' %}"></script>
+    <script type="text/javascript" src="{% static 'highcharts/highcharts.js' %}"></script>
     {% if contests|length == 0 %}
         {% url 'oioioiadmin:contests_contest_add' as link %}
         {% if can_create_contest %}

--- a/oioioi/statistics/plottypes.py
+++ b/oioioi/statistics/plottypes.py
@@ -58,7 +58,7 @@ class StaticHighchartsPlot(PlotType):
     """
 
     def head_libraries(self):
-        return ["highcharts/lib/highcharts.js"]
+        return ["highcharts/highcharts.js"]
 
     def highcharts_options(self, data):
         """Function generating options for Highcharts chart, as specified in

--- a/oioioi/workers/templates/workers/list_workers.html
+++ b/oioioi/workers/templates/workers/list_workers.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Workers list" %}{% endblock %}
 
 {% block main-content %}
-<script type="text/javascript" src="{% static "highcharts/lib/highcharts.js" %}"></script>
+<script type="text/javascript" src="{% static "highcharts/highcharts.js" %}"></script>
 <script type="text/javascript" src="{% static "common/load_chart.js" %}"></script>
 <script type="text/javascript">
     $(function() {


### PR DESCRIPTION
Highcharts changed the highcharts.js file location from highcharts/lib/ to highcharts/, this caused load failures.

Closes #757.
Closes #694.