### PR TITLE
Made easy_toolbox tests use multithreading by default

### DIFF
--- a/easy_toolbox.py
+++ b/easy_toolbox.py
@@ -59,8 +59,8 @@ RAW_COMMANDS = [
         "This will CLEAR the database.",
     ),
     ("add-superuser", "Create admin_admin.", "{exec} web python manage.py loaddata ../oioioi/oioioi_cypress/cypress/fixtures/admin_admin.json"),
-    ("test", "Run unit tests.", "{exec} web ../oioioi/test.sh {extra_args}"),
-    ("test-slow", "Run unit tests. (--runslow)", "{exec} web ../oioioi/test.sh --runslow {extra_args}"),
+    ("test", "Run unit tests.", "{exec} web ../oioioi/test.sh -n auto {extra_args}"),
+    ("test-slow", "Run unit tests. (--runslow)", "{exec} web ../oioioi/test.sh --runslow -n auto {extra_args}"),
     (
         "test-coverage",
         "Run coverage tests.",


### PR DESCRIPTION
Made the easy_toolbox test command utilize all cpu cores by default. On a good processor, this gave me around 5x speedup when testing locally, and I don't see why it shouldn't be the default. 

Nightly tests already use pytest's "-n auto" option anyways, so this is not a relaibility issue.

Runtimes for singlethreaded vs multithreaded tests for reference:
<img width="509" height="23" alt="image" src="https://github.com/user-attachments/assets/2251f2fc-4d8c-4f28-89dc-ba70ccb05928" />
<img width="401" height="21" alt="image" src="https://github.com/user-attachments/assets/382cc168-145e-44cb-9d73-37afa54f52be" />
