### PR TITLE
Fix notifications server error spam

### DIFF
--- a/oioioi/notifications/server/server.py
+++ b/oioioi/notifications/server/server.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from typing import NamedTuple
 from weakref import WeakValueDictionary
 
+from aiohttp import ClientResponseError
 from websockets.asyncio.server import ServerConnection, broadcast, serve
 from websockets.exceptions import ConnectionClosed
 
@@ -105,7 +106,13 @@ class Server:
             return user_id
 
         except Exception as e:
-            self.logger.error(f"Authentication error for session {session_id}: {type(e).__name__}, {e}")
+            msg = f"Authentication error for session {session_id}: {type(e).__name__}, {e}"
+            # 401 Unauthorized errors can happen if the user logs out in one tab, but doesn't
+            # refresh other ones, so we don't want error notifications in such cases.
+            if isinstance(e, ClientResponseError) and e.status == 401:
+                self.logger.warn(msg)
+            else:
+                self.logger.error(msg)
             return None
 
     async def _unregister_connection(self, user_id: str | None, websocket: ServerConnection) -> None:

--- a/oioioi/notifications/static/common/notifications.js
+++ b/oioioi/notifications/static/common/notifications.js
@@ -56,6 +56,7 @@ function NotificationsClient(serverUrl, sessionId) {
     this.NOTIF_SESSION = sessionId;
     this.socket = undefined;
     this.notifCount = 0;
+    this.authFailureCount = 0;
 
     this.dropdownUpToDate = false;
     this.dropdownLoading = false;
@@ -120,10 +121,16 @@ NotificationsClient.prototype.authenticate = function () {
 NotificationsClient.prototype.authenticateCallback = function (result) {
     if (result.status === 'OK') {
         this.notifCount = 0;
+        this.authFailureCount = 0;
         this.updateNotifCount();
         this.clearSocketErrorState();
     } else {
         console.warn("WebSocket authentication failed.");
+        this.authFailureCount++;
+        if (this.authFailureCount >= 3) {
+            console.warn("WebSocket authentication failure threshhold exceeded, giving up.");
+            this.socket.onclose = null;
+        }
 
         // Close the socket to attempt to reconnect
         this.socket?.close();


### PR DESCRIPTION
FOr local requests from the notification server to the main uwsgi, log 401 Unauthorized as warnings instead of errors, since they can happen if the user logs out in one tab, but doesn't refresh other ones (and the connection gets reset).


Also make notif client not retry indefinitely after failed auth.

This will stop the spam of errors sent to Sentry.