### PR TITLE
Fixup for showing memory usage in submission reports

### DIFF
--- a/oioioi/programs/models.py
+++ b/oioioi/programs/models.py
@@ -297,6 +297,19 @@ def make_output_filename(instance, filename):
     return f"userouts/{submission.problem_instance.contest.id!s}/{submission.id}/{instance.submission_report.id}-out"
 
 
+INTEGERFIELD_MAX_SIZE = 2**31 - 1
+
+
+def limit_mem_used(mem_used):
+    if mem_used is None:
+        return None
+    return min(mem_used, INTEGERFIELD_MAX_SIZE)
+
+
+def is_mem_used_overflowed(mem_used):
+    return mem_used == INTEGERFIELD_MAX_SIZE
+
+
 class TestReport(models.Model):
     __test__ = False
     submission_report = models.ForeignKey(SubmissionReport, on_delete=models.CASCADE)
@@ -336,6 +349,10 @@ class TestReport(models.Model):
         if contest is None or self.test_time_limit is None:
             return False
         return contest.controller.uses_threshold_linear_scoring() and self.time_used * 2 > self.test_time_limit
+
+    def save(self, *args, **kwargs):
+        self.mem_used = limit_mem_used(self.mem_used)
+        super().save(*args, **kwargs)
 
 
 class GroupReport(models.Model):

--- a/oioioi/programs/templates/programs/report-body.html
+++ b/oioioi/programs/templates/programs/report-body.html
@@ -58,14 +58,14 @@
                         <td>
                             {% if is_admin or test.status != 'TLE' %}
                                 {{ test.time_used|runtimeformat }}
-                            {% else %}-.--s
+                            {% else %}-.-- s
                             {% endif %}/ {{ test.test_time_limit|runtimeformat }}
                         </td>
                         {% if show_mem_used %}
                         <td>
                             {% if is_admin or test.status != 'MLE' %}
                                 {{ test.mem_used|memoryformat }}
-                            {% else %}--MiB
+                            {% else %}-- MiB
                             {% endif %}/ {{ test.test_mem_limit|memoryformat }}
                         </td>
                         {% endif %}

--- a/oioioi/programs/templatetags/memoryformat.py
+++ b/oioioi/programs/templatetags/memoryformat.py
@@ -1,6 +1,8 @@
 from django import template
 from django.utils.translation import gettext_lazy as _
 
+from oioioi.programs.models import is_mem_used_overflowed
+
 register = template.Library()
 
 
@@ -8,6 +10,8 @@ register = template.Library()
 def memoryformat(value):
     if value is None:
         return "???"
+    if is_mem_used_overflowed(value):
+        return "-- MiB"
     mebibytes = value / 1024.0
     if mebibytes < 10:
         return _("%(mebibytes).1f MiB") % {"mebibytes": mebibytes}

--- a/oioioi/testrun/controllers.py
+++ b/oioioi/testrun/controllers.py
@@ -270,10 +270,10 @@ class TestRunContestControllerMixin:
         output_container_id_prefix = "hidden_output_data_" if is_ajax(request) else "output_data_"
 
         input_is_zip = False
+        show_mem_used = False
         if testrun_report:
             input_is_zip = is_zipfile(testrun_report.submission_report.submission.programsubmission.testrunprogramsubmission.input_file.read_using_cache())
-
-        show_mem_used = testrun_report.mem_used > 0
+            show_mem_used = testrun_report.mem_used > 0
 
         return render_to_string(
             template,

--- a/oioioi/testrun/models.py
+++ b/oioioi/testrun/models.py
@@ -11,7 +11,7 @@ from oioioi.contests.models import (
 )
 from oioioi.filetracker.fields import FileField
 from oioioi.problems.models import ProblemInstance
-from oioioi.programs.models import ProgramSubmission
+from oioioi.programs.models import ProgramSubmission, limit_mem_used
 
 submission_statuses.register("TESTRUN_OK", _("No error"))
 submission_kinds.register("TESTRUN", _("Test run"))
@@ -70,3 +70,7 @@ class TestRunReport(models.Model):
     test_time_limit = models.IntegerField(null=True, blank=True)
     test_mem_limit = models.IntegerField(null=True, blank=True)
     output_file = FileField(upload_to=make_custom_output_filename)
+
+    def save(self, *args, **kwargs):
+        self.mem_used = limit_mem_used(self.mem_used)
+        super().save(*args, **kwargs)

--- a/oioioi/testrun/tests.py
+++ b/oioioi/testrun/tests.py
@@ -284,25 +284,28 @@ class TestHandlers(TestCase):
         try:
             environ["test_results"] = {}
             environ["test_results"]["test"] = {
-                "result_cpode": "OK",
+                "result_code": "OK",
                 "result_string": "OK",
                 "time_used": 111,
                 "out_file": "/output",
             }
+            cap = 2**31 - 1
+            for mem_used, expected_mem_used in ((44, 44), (cap, cap), (cap + 1, cap), (2**63, cap)):
+                environ["test_results"]["test"]["mem_used"] = mem_used
+                graded_environ = handlers.grade_submission(environ)
 
-            environ = handlers.grade_submission(environ)
+                self.assertEqual(None, graded_environ["score"])
+                self.assertEqual("TESTRUN_OK", graded_environ["status"])
 
-            self.assertEqual(None, environ["score"])
-            self.assertEqual("OK", environ["status"])
+                graded_environ = handlers.make_report(graded_environ)
+                self.assertIn("report_id", graded_environ)
+                report = TestRunReport.objects.get(submission_report=graded_environ["report_id"])
+                self.assertEqual(111, report.time_used)
+                self.assertEqual(expected_mem_used, report.mem_used)
+                self.assertEqual("", report.comment)
+                self.assertEqual(b"o", report.output_file.read())
 
-            environ = handlers.make_report(environ)
-            self.assertIn("report_id", environ)
-            report = TestRunReport.objects.get(submission_report=environ["report_id"])
-            self.assertEqual(111, report.time_used)
-            self.assertEqual("", report.comment)
-            self.assertEqual("o", report.output_file.read())
-
-            handlers.delete_output(environ)
+            handlers.delete_output(graded_environ)
         except Exception:
             get_client().delete_file("/output")
             raise

--- a/oioioi/testrun/tests.py
+++ b/oioioi/testrun/tests.py
@@ -305,6 +305,7 @@ class TestHandlers(TestCase):
             handlers.delete_output(environ)
         except Exception:
             get_client().delete_file("/output")
+            raise
 
 
 class TestRunTestCase:

--- a/oioioi/testrun/tests.py
+++ b/oioioi/testrun/tests.py
@@ -144,6 +144,12 @@ class TestTestrunViews(TestCase):
         self.assertContains(response, "TESTRUN")
         self.assertNotContains(response, "NORMAL")
 
+        kwargs["submission_id"] = submission.id
+        response = self.client.get(reverse("submission", kwargs=kwargs))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test run")
+        self.assertContains(response, "Compilation failed")
+
     def test_archive_submission(self):
         self.assertTrue(self.client.login(username="test_user"))
         kwargs = {"contest_id": Contest.objects.get().id}


### PR DESCRIPTION
Fixup for #660.
Closes #776 by limiting the stored memory usage to ~2 TiB, which will probably be visible only to admins, as for MLE the memory usage is hidden for non-admins.

Also fix a 500 error when viewing testrun submissions that resulted in compilation error, which don't have TestrunReports and add spaces before units in one related place that was missed.