### PR TITLE
Fix random failures when creating tag proposals in mass_create_tool

### DIFF
--- a/oioioi/problems/management/commands/mass_create_tool.py
+++ b/oioioi/problems/management/commands/mass_create_tool.py
@@ -390,34 +390,43 @@ class Command(BaseCommand):
 
     def create_proposals(self, count, problems, users, tags, proposal_model, verbose_name, verbosity):
         """
-        Creates algorithm tag proposals by pairing problems, users, and algotags randomly.
-        Returns a list of created AlgorithmTagProposal objects.
+        Creates exactly `count` distinct proposals connecting problems, users and tags.
+        - For DifficultyTagProposal: at most one per (problem, user) pair.
+        - For AlgorithmTagProposal: any unique (problem, user, tag) triple.
         """
+        if proposal_model == DifficultyTagProposal:
+            available = len(problems) * len(users)
+            if count > available:
+                raise CommandError(f"Cannot create {count} difficulty tag proposals; only {available} unique (problem, user) pairs available")
+            triples = []
+            for index in random.sample(range(available), count):
+                problem_index, user_index = divmod(index, len(users))
+                triples.append((problems[problem_index], users[user_index], random.choice(tags)))
+        else:
+            available = len(problems) * len(users) * len(tags)
+            if count > available:
+                raise CommandError(f"Cannot create {count} algorithm tag proposals; only {available} unique (problem, user, tag) triples available")
+            triples = []
+            for index in random.sample(range(available), count):
+                pair_index, tag_index = divmod(index, len(tags))
+                problem_index, user_index = divmod(pair_index, len(users))
+                triples.append((problems[problem_index], users[user_index], tags[tag_index]))
+
         objs = []
-        for i in range(count):
-
-            def candidate_fn():
-                return (random.choice(problems), random.choice(users), random.choice(tags))
-
-            def uniqueness_fn(candidate):
-                problem, user, tag = candidate
-                if proposal_model.__name__ == "AlgorithmTagProposal":
-                    return not proposal_model.objects.filter(problem=problem, user=user, tag=tag).exists()
-                elif proposal_model.__name__ == "DifficultyTagProposal":
-                    return not proposal_model.objects.filter(problem=problem, user=user).exists()
-                return True
-
-            problem, user, tag = get_unique_candidate(candidate_fn, uniqueness_fn)
+        for idx, (problem, user, tag) in enumerate(triples, start=1):
             proposal = proposal_model(problem=problem, user=user, tag=tag)
             proposal.save()
             objs.append(proposal)
+
             if verbosity >= 3:
                 self.stdout.write(self.style.SUCCESS(f"Created Proposal: Problem ID {problem.id} - User {user.username} - Tag {tag.name}"))
             elif verbosity == 2:
-                sys.stdout.write(f"Created {i + 1} of {count} {verbose_name}s\r")
+                sys.stdout.write(f"Created {idx} of {count} {verbose_name}s\r")
                 sys.stdout.flush()
+
         if verbosity == 2 and objs:
             sys.stdout.write("\n")
+
         return objs
 
     def write_summary(self, created, expected, object_name):

--- a/oioioi/problems/tests/test_commands.py
+++ b/oioioi/problems/tests/test_commands.py
@@ -83,6 +83,29 @@ class TestMassCreateTool(TestCase):
         call_command("mass_create_tool", "--wipe", stdout=out)
         self._assert_model_counts({})
 
+    def test_max_proposals(self):
+        out = StringIO()
+
+        # As many proposals as there are unique (problem, user, tag) triples and
+        # (problem, user) pairs, which is the worst case for drawing them at random.
+        mct_args = (
+            "--problems",
+            "3",
+            "--users",
+            "3",
+            "--algotags",
+            "2",
+            "--difftags",
+            "2",
+            "--algoproposals",
+            "18",
+            "--diffproposals",
+            "9",
+        )
+        call_command("mass_create_tool", *mct_args, stdout=out)
+        expected_counts = {name[2:]: int(value) for name, value in zip(mct_args[::2], mct_args[1::2], strict=False)}
+        self._assert_model_counts(expected_counts)
+
     def _contest_test_template(self, users, submissions_per_user, submission_files=("sum-correct.cpp", "sum-various-results.cpp")):
         out = StringIO()
         call_command(
@@ -258,6 +281,34 @@ class TestMassCreateTool(TestCase):
                 "1",
                 "-dp",
                 "1",
+                stdout=out,
+            )
+
+        # More proposals than there are unique combinations to draw from.
+        with self.assertRaises(CommandError):
+            call_command(
+                "mass_create_tool",
+                "-p",
+                "2",
+                "-u",
+                "2",
+                "-at",
+                "2",
+                "-ap",
+                "9",
+                stdout=out,
+            )
+        with self.assertRaises(CommandError):
+            call_command(
+                "mass_create_tool",
+                "-p",
+                "2",
+                "-u",
+                "2",
+                "-dt",
+                "2",
+                "-dp",
+                "5",
                 stdout=out,
             )
 


### PR DESCRIPTION
Fixes #649.

`mass_create_tool` retried random proposal candidates and failed after ten collisions, even when unused combinations were still available. This made proposal generation fail randomly as the requested count approached the number of possible combinations.

Draw unique combination indices without replacement and reject counts that exceed the available space. Add regression tests that fill the entire proposal space and verify invalid counts.