### PR TITLE
Speed up user group admin form

### DIFF
--- a/oioioi/usergroups/admin.py
+++ b/oioioi/usergroups/admin.py
@@ -18,7 +18,7 @@ def get_user_name_and_login_bounded(self, user):
 
 class UserGroupAdmin(admin.ModelAdmin):
     exclude = ("addition_config", "sharing_config", "contests")
-    filter_horizontal = ("owners", "members")
+    autocomplete_fields = ("owners", "members")
     search_fields = ("name",)
 
     def formfield_for_dbfield(self, db_field, request, **kwargs):
@@ -31,6 +31,21 @@ class UserGroupAdmin(admin.ModelAdmin):
             formfield.label_from_instance = types.MethodType(get_user_name_and_login_bounded, formfield)
 
         return formfield
+
+
+class UserGroupOwnerAutocompleteMixin:
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        if (
+            request.GET.get("app_label") == UserGroup._meta.app_label
+            and request.GET.get("model_name") == UserGroup._meta.model_name
+            and request.GET.get("field_name") == "owners"
+        ):
+            queryset = queryset.filter(models.Q(teacher__isnull=False) | models.Q(is_superuser=True))
+        return queryset, use_distinct
+
+
+admin.OioioiUserAdmin.mix_in(UserGroupOwnerAutocompleteMixin)
 
 
 admin.site.register(UserGroup, UserGroupAdmin)

--- a/oioioi/usergroups/tests.py
+++ b/oioioi/usergroups/tests.py
@@ -37,7 +37,7 @@ class TestAdmin(TestCase):
 
         self.assertContains(response, "Add user group")
         self.assertNotContains(response, "Addtion config")
-        self.assertContains(response, "Test User 3 (test_user3)")
+        self.assertNotContains(response, "Test User 3 (test_user3)")
 
         url = reverse("oioioiadmin:usergroups_usergroup_change", args=(1001,))
         response = self.client.get(url)
@@ -45,8 +45,8 @@ class TestAdmin(TestCase):
         self.assertContains(response, "Change user group")
         self.assertContains(response, "owners")
         self.assertNotContains(response, "Action config")
-        self.assertContains(response, "Test User 3 (test_user3)", count=1)
-        self.assertContains(response, "Test Admin (test_admin)", count=2)
+        self.assertNotContains(response, "Test User 3 (test_user3)")
+        self.assertContains(response, "Test Admin (test_admin)", count=1)
 
         url = reverse("oioioiadmin:usergroups_usergroup_delete", args=(1002,))
         response = self.client.get(url)
@@ -56,6 +56,22 @@ class TestAdmin(TestCase):
 
         self.assertRaises(NoReverseMatch, reverse, "oioioiadmin:usergroups_actionconfig_changelist")
         self.assertRaises(NoReverseMatch, reverse, "oioioiadmin:usergroups_actionconfig_add")
+
+    def test_user_autocomplete(self):
+        self.assertTrue(self.client.login(username="test_admin"))
+
+        url = reverse("oioioiadmin:autocomplete")
+        response = self.client.get(
+            url,
+            {"app_label": "usergroups", "model_name": "usergroup", "field_name": "owners", "term": "test_user"},
+        )
+        self.assertEqual({result["id"] for result in response.json()["results"]}, {"1001", "1002"})
+
+        response = self.client.get(
+            url,
+            {"app_label": "usergroups", "model_name": "usergroup", "field_name": "members", "term": "test_user"},
+        )
+        self.assertEqual({result["id"] for result in response.json()["results"]}, {"1001", "1002", "1003", "1005"})
 
     def test_permissions(self):
         self.assertTrue(self.client.login(username="test_admin"))


### PR DESCRIPTION
Fixes #711.

The user group admin form used `filter_horizontal`, which rendered all member candidates and all eligible owners when the page was opened. This switches both fields to Django autocomplete widgets.

Owner suggestions remain limited to teachers and superusers. The autocomplete endpoint uses `OioioiUserAdmin`, so the same restriction is applied there as well.

Tests:
- `pytest oioioi/usergroups/tests.py`
- `ruff check oioioi/usergroups/admin.py oioioi/usergroups/tests.py`
- `ruff format --check oioioi/usergroups/admin.py oioioi/usergroups/tests.py`