### PR TITLE
Fixed timelines being messy after update to bootstrap 5

### DIFF
--- a/oioioi/timeline/static/timeline/timeline.js
+++ b/oioioi/timeline/static/timeline/timeline.js
@@ -17,7 +17,6 @@ $(function() {
     var ROUND_BAR_CLASS = 'oioioi-timeline__round-bar';
     var ROUND_BAR_HTML = '<div class="' + ROUND_BAR_CLASS + '"></div>';
     var ROUND_GROUP_WIDTH = 35;
-    var ROUND_BAR_WIDTH = 30;
 
     // we don't want vertical connector parts to overlap, we draw every
     // subsequent connector a little bit more to the left if that should
@@ -141,7 +140,7 @@ If you want to split a date group, click the corresponding \
         return {
             min_date: new Date(Math.min.apply(null, dates)),
             max_date: new Date(Math.max.apply(null, dates))
-        }; 
+        };
     }
 
     function update_date_range() {

--- a/oioioi/timeline/static/timeline/timeline.js
+++ b/oioioi/timeline/static/timeline/timeline.js
@@ -54,10 +54,7 @@ If you want to split a date group, click the corresponding \
         gettext("now") + '</small></div>';
 
 
-    // Use the rendered datebox height rather than the form-control height.
-    // The latter does not include the input-group contents and is no longer
-    // reliable with Bootstrap 5.
-    var DATEBOX_HEIGHT = 40;
+    var DATEBOX_HEIGHT = parseInt($('.form-control').css('height'), 10) + 2;
     // a horizontal gap between round bars and datepickers
     var DATEBOX_GAP = 40;
     // a vertical gap used to separate datepickers with no date specified

--- a/oioioi/timeline/static/timeline/timeline.js
+++ b/oioioi/timeline/static/timeline/timeline.js
@@ -54,7 +54,10 @@ If you want to split a date group, click the corresponding \
         gettext("now") + '</small></div>';
 
 
-    var DATEBOX_HEIGHT = parseInt($('.form-control').css('height'), 10) + 2;
+    // Use the rendered datebox height rather than the form-control height.
+    // The latter does not include the input-group contents and is no longer
+    // reliable with Bootstrap 5.
+    var DATEBOX_HEIGHT = 40;
     // a horizontal gap between round bars and datepickers
     var DATEBOX_GAP = 40;
     // a vertical gap used to separate datepickers with no date specified
@@ -356,7 +359,7 @@ If you want to split a date group, click the corresponding \
                 my_top = target_position;
                 overlapping = 0;
             }
-            $this.css({left: datebox_left, top: my_top});
+            $this.css({left: datebox_left - roundGroupLeft, top: my_top});
             set_width($this);
             if (my_date !== null) {
                 $this.children('.oioioi-timeline__connector').show();
@@ -587,7 +590,13 @@ If you want to split a date group, click the corresponding \
         $timeline.find('.date').each(function () {
             initDateTimePicker(this)
         })
-        
+
+        var rendered_datebox_height = $timeline
+            .find('.oioioi-timeline__datebox').first().outerHeight(true);
+        if (rendered_datebox_height) {
+            DATEBOX_HEIGHT = rendered_datebox_height;
+        }
+
         // connect equal dates
         create_groups();
 

--- a/oioioi/timeline/static/timeline/timeline.scss
+++ b/oioioi/timeline/static/timeline/timeline.scss
@@ -50,7 +50,15 @@ $timeline-group-delete-btn-margin: 8px !default;
   }
 
   &__calendar-icon {
+    background-color: $gray-100;
+    color: $gray-550;
     width: auto;
+
+    &:hover,
+    &:focus {
+      background-color: $gray-200;
+      color: $gray-900;
+    }
   }
 
   &__date-input {

--- a/oioioi/timeline/templates/timeline/timeline_view.html
+++ b/oioioi/timeline/templates/timeline/timeline_view.html
@@ -61,7 +61,7 @@
                 <div id="datetimepickerbox_{{ round.0 }}_{{ forloop.counter }}" data-timeline-round-num="{{ round.0 }}" data-timeline-order="{{ record.order }}" data-timeline-type="{{ record.type }}" class="oioioi-timeline__datebox">
                     <div id="datetimepicker_{{ round.0 }}_{{ forloop.counter }}" class="input-group date inline float-start" data-td-target-input="nearest" data-td-target-toggle="nearest">
                         <input type="text" name="{{ record.date_id }}" class="oioioi-timeline__datetime-input form-control" value="{{ record.date|date:'Y-m-d H:i' }}" {{ attrs }} />
-                        <button class="btn btn-outline-secondary bg-light border datepickerbutton oioioi-timeline__calendar-icon" type="button" data-td-toggle="datetimepicker"><i class="fa-solid fa-calendar"></i></button>
+                        <button class="btn btn-outline-secondary border datepickerbutton oioioi-timeline__calendar-icon" type="button" data-td-toggle="datetimepicker"><i class="fa-solid fa-calendar"></i></button>
                         <div class="oioioi-timeline__date-title bg-transparent input-group-text text-white">{{ record.text }}<small class="group-members"></small></div>
                         <button class="btn btn-secondary border bg-transparent oioioi-timeline__group-delete-btn" type="button"><i class=" fa-solid fa-up-down"></i></button>
                     </div>

--- a/oioioi/timeline/templates/timeline/timeline_view.html
+++ b/oioioi/timeline/templates/timeline/timeline_view.html
@@ -61,11 +61,9 @@
                 <div id="datetimepickerbox_{{ round.0 }}_{{ forloop.counter }}" data-timeline-round-num="{{ round.0 }}" data-timeline-order="{{ record.order }}" data-timeline-type="{{ record.type }}" class="oioioi-timeline__datebox">
                     <div id="datetimepicker_{{ round.0 }}_{{ forloop.counter }}" class="input-group date inline float-start" data-td-target-input="nearest" data-td-target-toggle="nearest">
                         <input type="text" name="{{ record.date_id }}" class="oioioi-timeline__datetime-input form-control" value="{{ record.date|date:'Y-m-d H:i' }}" {{ attrs }} />
-                        <div class="input-group-append">
-                            <button class="btn btn-outline-secondary bg-light border datepickerbutton oioioi-timeline__calendar-icon" type="button" data-td-toggle="datetimepicker"><i class="fa-solid fa-calendar"></i></button>
-                            <div class="oioioi-timeline__date-title bg-transparent input-group-text text-white">{{ record.text }}<small class="group-members"></small></div>
-                            <button class="btn btn-secondary border bg-transparent oioioi-timeline__group-delete-btn" type="button"><i class=" fa-solid fa-up-down"></i></button>
-                        </div>
+                        <button class="btn btn-outline-secondary bg-light border datepickerbutton oioioi-timeline__calendar-icon" type="button" data-td-toggle="datetimepicker"><i class="fa-solid fa-calendar"></i></button>
+                        <div class="oioioi-timeline__date-title bg-transparent input-group-text text-white">{{ record.text }}<small class="group-members"></small></div>
+                        <button class="btn btn-secondary border bg-transparent oioioi-timeline__group-delete-btn" type="button"><i class=" fa-solid fa-up-down"></i></button>
                     </div>
                 </div>
                 {% endfor %}


### PR DESCRIPTION
There were some bootstrap problems after all, notably that bootstrap 5 expects input fields to be direct children of the input group rather than wrapped in a div.

Before:
<img width="579" height="686" alt="image" src="https://github.com/user-attachments/assets/cf2edfc7-5b86-41f3-ad50-49e4e10ff166" />
After:
<img width="558" height="772" alt="image" src="https://github.com/user-attachments/assets/4525b2b7-2786-4421-b190-20de7799595d" />

Closes #774 