### PR TITLE
Fix signal hints in test runs

### DIFF
--- a/oioioi/programs/controllers.py
+++ b/oioioi/programs/controllers.py
@@ -101,6 +101,23 @@ def get_report_display_type(request, test_report):
     return display_type
 
 
+def get_signal_from_comment(comment):
+    # Sioworkers doesn't give us exit codes or signals explicitly. Neither does sio2jail.
+    # This detection mechanism is similar to the one sioworkers uses to give a RE verdict:
+    # https://github.com/sio2project/sioworkers/blob/55776ac98613ff2b11bd63397be536029616b9bb/sio/workers/executors.py#L670
+    for signal_exit_msg in (
+        "process exited due to signal ",
+        "program exited due to signal ",
+    ):
+        if comment.startswith(signal_exit_msg):
+            try:
+                return int(comment[len(signal_exit_msg) :])
+            except ValueError:
+                return None
+
+    return None
+
+
 class ProgrammingProblemController(ProblemController):
     description = _("Simple programming problem")
 
@@ -691,23 +708,15 @@ class ProgrammingProblemController(ProblemController):
 
         groups = []
         signals_to_explain = set()
-        # Sioworkers doesn't give us exit codes or signals explicitly. Neither does sio2jail.
-        # This detection mechanism is similar to the one sioworkers uses to give a RE verdict:
-        # https://github.com/sio2project/sioworkers/blob/55776ac98613ff2b11bd63397be536029616b9bb/sio/workers/executors.py#L670
-        signal_exit_msg = "process exited due to signal "
         for group_name, tests in itertools.groupby(test_reports, attrgetter("test_group")):
             tests_list = list(tests)
 
             for test in tests_list:
                 test.generate_status = picontroller._out_generate_status(request, test)
                 all_outs_generated &= test.generate_status == "OK"
-                # Extract all error signals from the test report according to the format
-                if test.comment.startswith(signal_exit_msg):
-                    try:
-                        signal = int(test.comment[len(signal_exit_msg) :])
-                        signals_to_explain.add(signal)
-                    except ValueError:
-                        pass
+                signal = get_signal_from_comment(test.comment)
+                if signal is not None:
+                    signals_to_explain.add(signal)
                 if test.result_percentage_numerator and test.result_percentage_denominator:
                     test.result_percentage = f"""{round(test.result_percentage_numerator / test.result_percentage_denominator, 2):g}"""
 

--- a/oioioi/programs/tests.py
+++ b/oioioi/programs/tests.py
@@ -1855,6 +1855,13 @@ class TestReportDisplayTypes(TestCase):
         self.assertContains(response, "submission--OK25", count=2)
         self.assertContains(response, "submission--OK0", count=3)
 
+    def test_signal_hint(self):
+        self.assertTrue(self.client.login(username="test_user"))
+        url = reverse("submission", kwargs={"contest_id": "oi", "submission_id": 7})
+        response = self.client.get(url, follow=True)
+
+        self.assertContains(response, "Most common causes of the SIGABRT signal")
+
     def test_acm_display(self):
         self.assertTrue(self.client.login(username="admin"))
         url = reverse("submission", kwargs={"contest_id": "acm", "submission_id": 9})

--- a/oioioi/testrun/controllers.py
+++ b/oioioi/testrun/controllers.py
@@ -21,6 +21,7 @@ from oioioi.problems.utils import can_admin_problem, can_admin_problem_instance
 from oioioi.programs.controllers import (
     ProgrammingContestController,
     ProgrammingProblemController,
+    get_signal_from_comment,
 )
 from oioioi.programs.models import CompilationReport
 from oioioi.programs.problem_instance_utils import get_allowed_languages_extensions
@@ -274,6 +275,11 @@ class TestRunContestControllerMixin:
             input_is_zip = is_zipfile(testrun_report.submission_report.submission.programsubmission.testrunprogramsubmission.input_file.read_using_cache())
 
         show_mem_used = testrun_report.mem_used > 0
+        signals_to_explain = set()
+        if testrun_report:
+            signal = get_signal_from_comment(testrun_report.comment)
+            if signal is not None:
+                signals_to_explain.add(signal)
 
         return render_to_string(
             template,
@@ -286,6 +292,7 @@ class TestRunContestControllerMixin:
                 "output_container_id_prefix": output_container_id_prefix,
                 "input_is_zip": input_is_zip,
                 "show_mem_used": show_mem_used,
+                "signals_to_explain": signals_to_explain,
             },
         )
 

--- a/oioioi/testrun/templates/testrun/report.html
+++ b/oioioi/testrun/templates/testrun/report.html
@@ -68,6 +68,10 @@
     <p><strong>{% trans "Comment" %}:</strong> {{ testrun_report.comment }}</p>
 {% endif %}
 
+{% if signals_to_explain %}
+    {% include "programs/report-signal-hint.html" %}
+{% endif %}
+
 {% block output_collapse %}
 {% if is_admin %}
     <div id="{{ output_container_id_prefix }}{{ testrun_report.id }}" class="collapse" data-loadurl="{% url 'get_specific_testrun_output' contest_id=contest.id submission_id=testrun_report.submission_report.submission.id testrun_report_id=testrun_report.id %}">

--- a/oioioi/testrun/tests.py
+++ b/oioioi/testrun/tests.py
@@ -75,6 +75,29 @@ class TestTestrunViews(TestCase):
             no_whitespaces = re.sub(r"\s*", "", submission_view.content.decode("utf-8"))
             self.assertIn(">OK</td>", no_whitespaces)
 
+    def test_signal_hints(self):
+        self.assertTrue(self.client.login(username="test_user"))
+        submission = TestRunProgramSubmission.objects.get(pk=1)
+        report = TestRunReport.objects.get(submission_report__submission=submission)
+        url = reverse(
+            "submission",
+            kwargs={
+                "contest_id": submission.problem_instance.contest.id,
+                "submission_id": submission.id,
+            },
+        )
+
+        for prefix in ["process", "program"]:
+            report.comment = f"{prefix} exited due to signal 6"
+            report.save(update_fields=["comment"])
+            response = self.client.get(url)
+            self.assertContains(response, "Most common causes of the SIGABRT signal")
+
+        report.comment = "program exited due to signal invalid"
+        report.save(update_fields=["comment"])
+        response = self.client.get(url)
+        self.assertNotContains(response, "Most common causes of the SIGABRT signal")
+
     def test_input_views(self):
         self.assertTrue(self.client.login(username="test_user"))
         submission = TestRunProgramSubmission.objects.get(pk=1)


### PR DESCRIPTION
Fixes #354.

Signal hints were only extracted from regular test reports and only recognized the `process exited due to signal` format. Test runs use a separate report template, while sioworkers can also produce `program exited due to signal`.

This recognizes both formats in one place and passes the extracted signal to the test run template, reusing the existing error hint.

The regression tests fail without the implementation and pass with it.

Tests:
- `pytest oioioi/programs/tests.py::TestReportDisplayTypes::test_signal_hint oioioi/testrun/tests.py::TestTestrunViews::test_signal_hints`
- `pytest oioioi/programs/tests.py oioioi/testrun/tests.py`
- `ruff check oioioi/programs/controllers.py oioioi/programs/tests.py oioioi/testrun/controllers.py oioioi/testrun/tests.py`
- `ruff format --check oioioi/programs/controllers.py oioioi/programs/tests.py oioioi/testrun/controllers.py oioioi/testrun/tests.py`